### PR TITLE
(fix) Bump version of react-localization

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
     "express": "^4.14.0",
     "react": "^15.3.0",
     "react-dom": "^15.3.0",
-    "react-localization": "0.0.3"
+    "react-localization": "0.0.8"
   }
 }


### PR DESCRIPTION
Outdated version of react-localization would throw errors in a variety of navigator permutations.