### PR TITLE
Eli prevent app css impacting inspector styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "react-datetime": "^2.8.10",
     "react-dom": "^15.6.1",
     "react-dropzone": "^3.13.3",
+    "react-frame-component": "^1.1.1",
     "react-localization": "^0.1.1",
     "react-select": "^1.0.0-rc.5",
     "react-toggle-button": "^2.1.0",

--- a/src/components/Simulator.js
+++ b/src/components/Simulator.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import events from 'events';
+import Frame from 'react-frame-component';
 import LocalizedStrings from 'react-localization';
 import Inspector from './Inspector';
 import AppContainer from './AppContainer';
@@ -171,7 +172,7 @@ class Simulator extends React.Component {
     const { definition } = props;
     const { unPublishedApplicationVariables, duration, submit } = state;
     return (
-      <div className="Inspector" style={inspectorStyle}>
+      <Frame className="Inspector" style={inspectorStyle}>
         <Inspector
           submitAppVars={submitAppVars}
           definition={definition}
@@ -182,7 +183,7 @@ class Simulator extends React.Component {
           submit={submit}
           strings={strings}
         />
-      </div>
+      </Frame>
     );
   }
   render() {


### PR DESCRIPTION
# Wrap Inspector in Iframe

This change wraps the inspector in an iframe to prevent css bleed from applications changing the inspector styles.

See how it looks with weather app below.
![image](https://user-images.githubusercontent.com/10850824/29533698-e7818a1c-8667-11e7-8907-55abd6dac188.png)
