### PR TITLE
Transform package exports to CJS

### DIFF
--- a/packages/mira-kit/package.json
+++ b/packages/mira-kit/package.json
@@ -19,6 +19,7 @@
     "@babel/core": "7.0.0-beta.42",
     "babel-core": "^7.0.0-0",
     "babel-jest": "22.1.0",
+    "babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
     "babel-preset-react-app": "next",
     "enzyme": "^3.2.0",
     "enzyme-adapter-react-15": "^1.0.5",
@@ -27,7 +28,8 @@
     "react-test-renderer": "^15.6.1"
   },
   "babel": {
-    "presets": ["react-app"]
+    "presets": ["react-app"],
+    "plugins": ["transform-es2015-modules-commonjs"]
   },
   "jest": {
     "transform": {

--- a/packages/mira-scripts/package.json
+++ b/packages/mira-scripts/package.json
@@ -53,8 +53,5 @@
     "webpack": "3.10.0",
     "webpack-dev-server": "2.11.0",
     "whatwg-fetch": "^2.0.3"
-  },
-  "babel": {
-    "presets": ["react-app"]
   }
 }

--- a/packages/mira-simulator/package.json
+++ b/packages/mira-simulator/package.json
@@ -11,6 +11,7 @@
   },
   "files": ["lib", "dist", "preview.html", "preview.js"],
   "dependencies": {
+    "babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
     "eventemitter3": "^3.0.1",
     "mira-elements": "^0.26.6",
     "mira-kit": "^2.0.4",
@@ -33,6 +34,7 @@
     "webpack-dev-server": "2.11.0"
   },
   "babel": {
-    "presets": ["react-app"]
+    "presets": ["react-app"],
+    "plugins": ["transform-es2015-modules-commonjs"]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1255,9 +1255,25 @@ babel-plugin-transform-dynamic-import@2.0.0:
   dependencies:
     "@babel/plugin-syntax-dynamic-import" "7.0.0-beta.34"
 
+babel-plugin-transform-es2015-modules-commonjs@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz#0d8394029b7dc6abe1a97ef181e00758dd2e5d8a"
+  dependencies:
+    babel-plugin-transform-strict-mode "^6.24.1"
+    babel-runtime "^6.26.0"
+    babel-template "^6.26.0"
+    babel-types "^6.26.0"
+
 babel-plugin-transform-react-remove-prop-types@0.4.12:
   version "0.4.12"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.12.tgz#a382c27c42d6580748c80caf8c3d5091edbb60b8"
+
+babel-plugin-transform-strict-mode@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz#d5faf7aa578a65bbe591cf5edae04a0c67020758"
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-types "^6.24.1"
 
 babel-preset-jest@^22.1.0, babel-preset-jest@^22.4.3:
   version "22.4.3"
@@ -1337,7 +1353,7 @@ babel-traverse@^6.18.0, babel-traverse@^6.26.0:
     invariant "^2.2.2"
     lodash "^4.17.4"
 
-babel-types@^6.18.0, babel-types@^6.26.0:
+babel-types@^6.18.0, babel-types@^6.24.1, babel-types@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
   dependencies:


### PR DESCRIPTION
`babel-preset-react-app` doesn't transform ejs modules. We need to do that here because these packages are expected to be consumed by other apps.  