### PR TITLE
Add ability to set presentation via query param

### DIFF
--- a/examples/menu/mira.config.js
+++ b/examples/menu/mira.config.js
@@ -4,7 +4,7 @@ export default {
   name: 'Menu',
   description: 'Easily create and display customized menus.',
   callToAction: 'Create Menu',
-  presentationProperties: {
+  properties: {
     categories: array('Categories', 'Category').items({
       name: string('Category').required(),
       items: array('Items', 'Item').items({
@@ -18,44 +18,49 @@ export default {
       .default(15)
       .helperText('Time in seconds.'),
   },
-  applicationVariables: {
-    Menu: {
-      categories: [
-        {
-          name: 'Sandwiches',
-          items: [
+  simulator: {
+    presentations: [
+      {
+        name: 'Menu',
+        values: {
+          categories: [
             {
-              name: 'Cuban',
-              itemDescription: 'The king of ham and cheese sandwiches.',
-              price: '5',
+              name: 'Sandwiches',
+              items: [
+                {
+                  name: 'Cuban',
+                  itemDescription: 'The king of ham and cheese sandwiches.',
+                  price: '5',
+                },
+                {
+                  name: 'Reuben',
+                  itemDescription:
+                    "A good ole' fashioned Corned Beef Reuben Sandwich. Pile it high and serve on rye.",
+                  price: '6',
+                },
+              ],
             },
             {
-              name: 'Reuben',
-              itemDescription:
-                "A good ole' fashioned Corned Beef Reuben Sandwich. Pile it high and serve on rye.",
-              price: '6',
+              name: 'Entrees',
+              items: [
+                {
+                  name: 'Steak Frites',
+                  itemDescription:
+                    'Norwich, ON AAA 8oz. New York striploin / fresh cut Yukon frites / cabernet shallot jus / truffle aïoli.',
+                  price: '28',
+                },
+                {
+                  name: 'Zucchini Rigatoni',
+                  itemDescription:
+                    'Ricotta / grape tomato / zucchini pesto / garlic / extra virgin olive oil / kale / potato crumble',
+                  price: '20',
+                },
+              ],
             },
           ],
         },
-        {
-          name: 'Entrees',
-          items: [
-            {
-              name: 'Steak Frites',
-              itemDescription:
-                'Norwich, ON AAA 8oz. New York striploin / fresh cut Yukon frites / cabernet shallot jus / truffle aïoli.',
-              price: '28',
-            },
-            {
-              name: 'Zucchini Rigatoni',
-              itemDescription:
-                'Ricotta / grape tomato / zucchini pesto / garlic / extra virgin olive oil / kale / potato crumble',
-              price: '20',
-            },
-          ],
-        },
-      ],
-    },
-    'New Presentation': {},
+      },
+      { name: 'New Presentation' },
+    ],
   },
 };

--- a/examples/video-player/mira.config.js
+++ b/examples/video-player/mira.config.js
@@ -4,25 +4,33 @@ export default {
   name: 'Video Player',
   description: 'Upload videos to your library.',
   callToAction: 'Upload Video',
-  presentationProperties: {
+  properties: {
     video: video('Video')
       .helperText('Supports .mp4, .mpeg and .mov')
       .required(),
     mute: boolean('Mute').default(true),
   },
-  applicationVariables: {
-    'Mira Intro': {
-      video: {
-        filename: 'mira-intro.mp4',
-        url: 'mira-intro.mp4',
+  simulator: {
+    presentations: [
+      {
+        name: 'Mira Intro',
+        values: {
+          video: {
+            filename: 'mira-intro.mp4',
+            url: 'mira-intro.mp4',
+          },
+        },
       },
-    },
-    Bars: {
-      video: {
-        filename: 'bars.mp4',
-        url: 'bars.mp4',
+      {
+        name: 'Bars',
+        values: {
+          video: {
+            filename: 'bars.mp4',
+            url: 'bars.mp4',
+          },
+        },
       },
-    },
-    'New Presentation': {},
+      { name: 'New Presentation' },
+    ],
   },
 };

--- a/examples/video-player/mira.config.js
+++ b/examples/video-player/mira.config.js
@@ -30,6 +30,15 @@ export default {
           },
         },
       },
+      {
+        name: 'Not Found',
+        values: {
+          video: {
+            filename: 'notfound.mp4',
+            url: 'notfound.mp4',
+          },
+        },
+      },
       { name: 'New Presentation' },
     ],
   },

--- a/examples/weather/mira.config.js
+++ b/examples/weather/mira.config.js
@@ -5,7 +5,7 @@ export default {
   description: 'Display local weather conditions.',
   callToAction: 'Add Weather',
   allowedRequestDomains: ['api.openweathermap.org'],
-  presentationProperties: {
+  properties: {
     city: string('City')
       .helperText('eg. San Francisco, US')
       .required(),
@@ -18,11 +18,25 @@ export default {
       .default(15)
       .helperText('Time in seconds.'),
   },
-  applicationVariables: {
-    'San Francisco': { city: 'San Francisco, US', units: 'imperial' },
-    Toronto: { city: 'Toronto, CA', units: 'metric' },
-    Sydney: { city: 'Sydney, AU', units: 'metric' },
-    'New Presentation': {},
-    'Not Found': { city: 'Not found' },
+  simulator: {
+    presentations: [
+      {
+        name: 'San Francisco',
+        values: { city: 'San Francisco, US', units: 'imperial' },
+      },
+      {
+        name: 'Toronto',
+        values: { city: 'Toronto, CA', units: 'metric' },
+      },
+      {
+        name: 'Sydney',
+        values: { city: 'Sydney, AU', units: 'metric' },
+      },
+      {
+        name: 'Not Found',
+        values: { city: 'Not found' },
+      },
+      { name: 'New Presentation' },
+    ],
   },
 };

--- a/packages/mira-kit/src/prop-types/extractProperties.js
+++ b/packages/mira-kit/src/prop-types/extractProperties.js
@@ -3,6 +3,8 @@ export default function extractProperties(
   properties = [],
   strings = {},
 ) {
+  if (!propTypes) return { properties, strings };
+
   Object.keys(propTypes).forEach(propName => {
     const propType = propTypes[propName].toJSON();
 

--- a/packages/mira-kit/src/prop-types/extractProperties.test.js
+++ b/packages/mira-kit/src/prop-types/extractProperties.test.js
@@ -14,6 +14,12 @@ import { imageContentTypes } from './ImageType';
 import { videoContentTypes } from './VideoType';
 import { defaultMaxSize } from './FileType';
 
+test('Should return empty properties and strings for empty propTypes', () => {
+  const { properties, strings } = extractProperties();
+  expect(strings).toEqual({});
+  expect(properties).toEqual([]);
+});
+
 test('Should extract properties from array', () => {
   const propTypes = {
     optional: array('Items', 'Item').items({ string: string('String') }),

--- a/packages/mira-kit/src/withMiraApp.js
+++ b/packages/mira-kit/src/withMiraApp.js
@@ -50,6 +50,11 @@ export default App => {
       });
     }
 
+    componentWillReceiveProps() {
+      // Clear any previous errors to allow the app to recover.
+      this.setState({ error: null });
+    }
+
     handlePresentationReady = () => {
       // Emit presentation_ready after fetching initial resources.
       // Applications are preloaded before switching to the next
@@ -69,17 +74,16 @@ export default App => {
     };
 
     handlePresentationError = error => {
-      // Fire presentation complete immediately if we are the active
-      // presentation (already received the play event). Otherwise, fire
-      // presentation_ready and wait until we receive the play event.
+      // Fire presentation complete immediately if we are currently playing.
+      // Otherwise, fire presentation_ready so that play is triggered.
       if (this.state.isPlaying) {
         this.handlePresentationComplete();
       } else {
-        // Only show the error if the app hasn't fired presentation_ready before
-        // an error occurs.
-        this.setState({ error });
         this.handlePresentationReady();
       }
+
+      // Show the error.
+      this.setState({ error });
 
       console.error(
         `App ${appName ? `'${appName}' ` : ''}errored: ${error.message}`,

--- a/packages/mira-kit/src/withMiraApp.test.js
+++ b/packages/mira-kit/src/withMiraApp.test.js
@@ -79,7 +79,7 @@ test('Should pass play to App on play event', () => {
   expect(wrapper.find(App).props().playCount).toEqual(1);
 });
 
-test('Should fire presentation_complete with timeout on error BEFORE play', () => {
+test('Should fire presentation_ready with timeout on error BEFORE play', () => {
   jest.useFakeTimers();
   const props = createProps();
   jest.spyOn(props.miraEvents, 'emit');
@@ -104,7 +104,7 @@ test('Should fire presentation_complete with timeout on error BEFORE play', () =
   jest.useRealTimers();
 });
 
-test('Should fire presentation_complete and NOT set error state on error AFTER play', () => {
+test('Should fire presentation_complete on error AFTER play', () => {
   const props = createProps();
   jest.spyOn(props.miraEvents, 'emit');
   const MiraApp = withMiraApp(App);
@@ -113,7 +113,6 @@ test('Should fire presentation_complete and NOT set error state on error AFTER p
   onReady();
   props.miraEvents.emit('play');
   onError(new Error());
-  expect(wrapper.state().error).toBeNull();
   expect(props.miraEvents.emit).toHaveBeenCalledTimes(3);
   expect(props.miraEvents.emit.mock.calls[0][0]).toEqual('presentation_ready');
   expect(props.miraEvents.emit.mock.calls[1][0]).toEqual('play');
@@ -135,6 +134,18 @@ test('Should increment playCount', () => {
   props.miraEvents.emit('play');
   expect(mockApp).toHaveBeenCalledTimes(3);
   expect(mockApp.mock.calls[2][0].playCount).toEqual(2);
+});
+
+test('Should reset error state on props update', () => {
+  const props = createProps();
+  const MiraApp = withMiraApp(App);
+  const wrapper = shallow(<MiraApp {...props} />);
+  const { onError } = wrapper.find(App).props();
+  const error = new Error();
+  onError(error);
+  expect(wrapper.state().error).toEqual(error);
+  wrapper.setProps(props);
+  expect(wrapper.state().error).toEqual(null);
 });
 
 test('Should return true for valid Mira app', () => {

--- a/packages/mira-scripts/template/README.md
+++ b/packages/mira-scripts/template/README.md
@@ -1,8 +1,8 @@
-### ![](icon.svg) _Name_
+## _App Name_
 
 _Description_
 
-#### Presentation Properties
+#### Properties
 
 | Name       | Type     | Description                  |
 | ---------- | -------- | ---------------------------- |

--- a/packages/mira-scripts/template/mira.config.js
+++ b/packages/mira-scripts/template/mira.config.js
@@ -4,13 +4,13 @@ export default {
   name: 'My Mira App',
   description: 'Create your first app with MiraKit.',
   callToAction: 'Create App',
-  presentationProperties: {
+  properties: {
     duration: PropTypes.number('Duration')
       .min(5)
       .default(10)
       .helperText('Time in seconds.'),
   },
-  applicationVariables: {
-    'New Presentation': {},
+  simulator: {
+    presentations: [{ name: 'New Presentation' }],
   },
 };

--- a/packages/mira-scripts/template/src/styles.css
+++ b/packages/mira-scripts/template/src/styles.css
@@ -7,7 +7,7 @@ main {
   font-family: sans-serif;
   font-size: 175%;
   color: white;
-  background: #16161d;
+  background: #22202b;
   line-height: 1.5;
 }
 

--- a/packages/mira-simulator/package.json
+++ b/packages/mira-simulator/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
     "eventemitter3": "^3.0.1",
+    "fast-deep-equal": "^1.1.0",
     "mira-elements": "^0.26.6",
     "mira-kit": "^2.1.0",
     "mira-resources": "^2.1.0",

--- a/packages/mira-simulator/src/AppLoader.js
+++ b/packages/mira-simulator/src/AppLoader.js
@@ -161,7 +161,7 @@ const styles = {
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
-    backgroundColor: '#16161D',
+    backgroundColor: '#22202b',
     color: 'rgba(255, 255, 255, 0.85)',
     fontSize: 40,
   },

--- a/packages/mira-simulator/src/AppPreview.js
+++ b/packages/mira-simulator/src/AppPreview.js
@@ -23,15 +23,20 @@ window.fetch = captureSandboxFailure('fetch', 'miraRequestResource');
 class AppPreview extends Component {
   static propTypes = {
     application: PropTypes.object.isRequired,
-    applicationVariables: PropTypes.object.isRequired,
-    allowedRequestDomains: PropTypes.arrayOf(PropTypes.string).isRequired,
+    allowedRequestDomains: PropTypes.arrayOf(PropTypes.string),
+    simulatorOptions: PropTypes.object,
+  };
+
+  static defaultProps = {
+    allowedRequestDomains: [],
+    simulatorOptions: { presentations: [] },
   };
 
   state = {};
   miraEvents = new EventEmitter();
 
   componentDidMount() {
-    const { application, applicationVariables } = this.props;
+    const { application, simulatorOptions } = this.props;
 
     this.messenger = createMessenger(
       window,
@@ -49,7 +54,7 @@ class AppPreview extends Component {
     // Send the application definition and all app variables to the parent window.
     this.messenger.send('init', {
       application,
-      applicationVariables,
+      simulatorOptions,
     });
   }
 

--- a/packages/mira-simulator/src/Simulator.js
+++ b/packages/mira-simulator/src/Simulator.js
@@ -127,16 +127,17 @@ class MiraAppSimulator extends Component {
       );
 
       // If a presentation exists in state it means the user has updated the
-      // form values, presenting or has passed in a presentation from the query string.
+      // form values, is in present mode or has passed in a presentation from
+      // the query string.
       if (presentation) {
         if (!isNaN(presentation.id)) {
-          // Use the query string presentation values over what's defined in the simulator
-          // config to allow users to edit the values in the form and have them persist
-          // through a page refresh.
+          // Use the query string presentation values over what's defined in the
+          // simulator config to allow users to edit the values in the form and
+          // have them persist through a page refresh.
           state.simulatorOptions.presentations[presentation.id] = presentation;
         } else {
-          // If a presentation id isn't provided or valid, add the presentation to the end
-          // of the simulator presentations with a new id.
+          // If a presentation id isn't provided or valid, add the presentation
+          // to the end of the simulator presentations with a new id.
           state.presentation.id = state.simulatorOptions.presentations.length;
           state.simulatorOptions.presentations.push(state.presentation);
         }

--- a/packages/mira-simulator/src/Simulator.js
+++ b/packages/mira-simulator/src/Simulator.js
@@ -1,3 +1,4 @@
+import deepEqual from 'fast-deep-equal';
 import {
   ThemeProvider,
   Container,
@@ -9,21 +10,24 @@ import querystring from 'querystring';
 import React, { Component } from 'react';
 import AppLoader from './AppLoader';
 import Icon from './Icon';
+import logger from './logger';
+import mergeDefaultAppVars from './mergeDefaultAppVars';
 
 const PRESENTATION_MIN_DURATION = 5;
+const EMPTY_PRESENTATION = { name: 'New Presentation', application_vars: {} };
+const EMPTY_APPLICATION = { icon_url: '', presentation_properties: [] };
 
 class MiraAppSimulator extends Component {
   initialState = {
-    presentation: { application_vars: {} },
-    previewPresentation: { application_vars: {} },
-    application: { icon_url: '', presentation_properties: [] },
-    applicationVariables: {},
+    presentation: null,
+    presentationPreview: null,
+    application: null,
     previewMode: 'horizontal',
     fullScreen: false,
-    index: 0,
     present: false,
     hideControls: false,
     enableLogs: true,
+    simulatorOptions: { presentations: [] },
   };
 
   queuedPresentationPreview = null;
@@ -37,9 +41,6 @@ class MiraAppSimulator extends Component {
     if (queryParams.previewMode) {
       state.previewMode = queryParams.previewMode;
     }
-    if (queryParams.index) {
-      state.index = parseInt(queryParams.index, 10);
-    }
     if (queryParams.fullScreen) {
       state.fullScreen = true;
       state.hideControls = true;
@@ -49,6 +50,20 @@ class MiraAppSimulator extends Component {
     }
     if (queryParams.enableLogs === 'false') {
       state.enableLogs = false;
+    }
+    if (queryParams.presentation) {
+      try {
+        const presentation = JSON.parse(
+          decodeURIComponent(queryParams.presentation),
+        );
+        if (!presentation.application_vars) {
+          throw new Error('Missing application_vars');
+        }
+        state.presentation = presentation;
+        state.presentationPreview = state.presentation;
+      } catch (err) {
+        logger.warning('Could not parse presentation from querystring.');
+      }
     }
 
     this.setState(state);
@@ -60,14 +75,16 @@ class MiraAppSimulator extends Component {
     if (this.hasStateChanged('previewMode')) {
       queryParams.previewMode = this.state.previewMode;
     }
-    if (this.hasStateChanged('index')) {
-      queryParams.index = this.state.index;
-    }
     if (this.hasStateChanged('fullScreen')) {
       queryParams.fullScreen = this.state.fullScreen;
     }
     if (this.hasStateChanged('present')) {
       queryParams.present = this.state.present;
+    }
+    if (this.hasStateChanged('presentation')) {
+      queryParams.presentation = encodeURIComponent(
+        JSON.stringify(this.state.presentation || {}),
+      );
     }
 
     const qs = querystring.stringify(queryParams);
@@ -75,7 +92,7 @@ class MiraAppSimulator extends Component {
   }
 
   hasStateChanged(key) {
-    return this.state[key] !== this.initialState[key];
+    return !deepEqual(this.state[key], this.initialState[key]);
   }
 
   startHideControlsTimer = () => {
@@ -88,96 +105,110 @@ class MiraAppSimulator extends Component {
     }
   };
 
-  setStateAtIndex = (
-    index,
-    application = this.state.application,
-    applicationVariables = this.state.applicationVariables,
-  ) => {
-    // Setting a new id will trigger the form to update state from props
-    // and cause the app preview to reload. We use index as part of the id
-    // to reload the preview when index changes. We use applicationVariables
-    // in the id to ensure theform is updated whenever we change mira.config.js
-    let id = `${index}-${JSON.stringify(applicationVariables)}`;
-    let name;
-    let appVars;
-
-    if (this.state.presentation.id === id) {
-      // If the current presentation id is equal to the current one, re-use
-      // the current application variables.
-      name = this.state.presentation.name;
-      appVars = this.state.presentation.application_vars;
-    } else {
-      // We are rendering a new presentation, reset to the application varibles
-      // set in mira.config.js
-      const appVarNames = Object.keys(applicationVariables);
-      // Set the selected app var to the index or the first one if not found.
-      const selectedAppVar = appVarNames[index] || appVarNames[0];
-      name = selectedAppVar;
-      appVars = applicationVariables[selectedAppVar] || {};
-    }
-
-    // Merge in defaults.
-    application.presentation_properties.forEach(prop => {
-      if (
-        typeof prop.default !== 'undefined' &&
-        typeof appVars[prop.name] === 'undefined'
-      ) {
-        appVars[prop.name] = prop.default;
-      }
-    });
-
-    const presentation = {
-      id: id,
-      name: name || '',
-      application_vars: appVars,
-    };
-
-    this.setState({
-      index,
+  // setOptions is called whenever the app is loaded. This happens
+  // on first page load but also when the app code has changed, causing
+  // webpack to reload the app preview.
+  setOptions = (application, simulatorOptions) => {
+    const { presentation } = this.state;
+    const state = {
       presentation,
       application,
-      applicationVariables,
-      previewPresentation: presentation,
-    });
+      simulatorOptions,
+    };
+
+    if (simulatorOptions.presentations) {
+      // Map over presentations to add a unique id (index) to each one.
+      state.simulatorOptions.presentations = state.simulatorOptions.presentations.map(
+        (p, index) => ({
+          id: index,
+          name: p.name,
+          application_vars: p.values || {},
+        }),
+      );
+
+      // If a presentation exists in state it means the user has updated the
+      // form values, presenting or has passed in a presentation from the query string.
+      if (presentation) {
+        if (!isNaN(presentation.id)) {
+          // Use the query string presentation values over what's defined in the simulator
+          // config to allow users to edit the values in the form and have them persist
+          // through a page refresh.
+          state.simulatorOptions.presentations[presentation.id] = presentation;
+        } else {
+          // If a presentation id isn't provided or valid, add the presentation to the end
+          // of the simulator presentations with a new id.
+          state.presentation.id = state.simulatorOptions.presentations.length;
+          state.simulatorOptions.presentations.push(state.presentation);
+        }
+      } else {
+        // No presentation currently set, use the first one in the simulator config.
+        const firstPresentation = simulatorOptions.presentations[0];
+        state.presentation = firstPresentation;
+      }
+    }
+
+    // Immediately update the preview.
+    state.presentationPreview = state.presentation;
+
+    this.setState(state);
   };
 
-  setPresentation = (presentation, changedProp) => {
-    let previewPresentation;
+  queuePresentationUpdate = (presentation, changedProp) => {
+    let presentationPreview;
 
     // Delay updating the preview for text and string inputs until onBlur.
     if (changedProp.type === 'string' || changedProp.type === 'text') {
       this.queuedPresentationPreview = presentation;
-      previewPresentation = this.state.previewPresentation;
+      presentationPreview = this.state.presentationPreview;
     } else {
       // Immediately update presentation preview.
-      previewPresentation = presentation;
+      presentationPreview = presentation;
       // Clear any queued preview updates because we're about to update.
       this.queuedPresentationPreview = null;
     }
 
-    this.setState({ previewPresentation, presentation });
+    this.setState({ presentationPreview, presentation });
   };
 
   flushPreviewUpdate = () => {
     // Flush any queued preview updates.
     if (this.queuedPresentationPreview) {
-      this.setState({ previewPresentation: this.queuedPresentationPreview });
+      this.setState({ presentationPreview: this.queuedPresentationPreview });
       this.queuedPresentationPreview = null;
     }
   };
 
-  renderControls() {
-    const {
-      index,
-      fullScreen,
-      hideControls,
-      present,
-      applicationVariables,
-    } = this.state;
-    const count = Object.keys(applicationVariables).length;
+  nextPresentation = () => {
+    const { presentation, simulatorOptions } = this.state;
+    const count = simulatorOptions.presentations.length;
+    let index = presentation.id;
+    // Show the next presentation in the list.
     const nextIndex = (index + 1) % count;
+    const nextPresentation = simulatorOptions.presentations[nextIndex];
+
+    this.setState({
+      presentation: nextPresentation,
+      presentationPreview: nextPresentation,
+    });
+  };
+
+  previousPresentation = () => {
+    const { presentation, simulatorOptions } = this.state;
+    const count = simulatorOptions.presentations.length;
+    let index = presentation.id;
+    // Show the previous presentation in the list.
     const previousIndex = ((index - 1) % count + count) % count;
-    const shouldShowPlay = count > 1;
+    const previousPresentation = simulatorOptions.presentations[previousIndex];
+
+    this.setState({
+      presentation: previousPresentation,
+      presentationPreview: previousPresentation,
+    });
+  };
+
+  renderControls() {
+    const { fullScreen, hideControls, present, simulatorOptions } = this.state;
+    const shouldShowPlay = simulatorOptions.presentations.length > 1;
 
     return (
       <ThemeProvider theme={fullScreen ? 'dark' : 'light'}>
@@ -194,7 +225,7 @@ class MiraAppSimulator extends Component {
               <Button
                 shrinkwrap
                 disabled={present}
-                onClick={() => this.setStateAtIndex(previousIndex)}
+                onClick={this.previousPresentation}
               >
                 <Icon icon="previous" />
               </Button>
@@ -209,7 +240,7 @@ class MiraAppSimulator extends Component {
               <Button
                 shrinkwrap
                 disabled={present}
-                onClick={() => this.setStateAtIndex(nextIndex)}
+                onClick={this.nextPresentation}
               >
                 <Icon icon="next" />
               </Button>
@@ -221,47 +252,48 @@ class MiraAppSimulator extends Component {
   }
 
   renderPreview() {
-    const {
-      index,
-      previewMode,
-      present,
-      enableLogs,
-      previewPresentation,
+    const { previewMode, present, enableLogs } = this.state;
+    let { presentationPreview, application } = this.state;
+
+    presentationPreview = presentationPreview || EMPTY_PRESENTATION;
+    application = application || EMPTY_APPLICATION;
+
+    // We don't care about name not being set to render the preview
+    // so we hard-code a valid name.
+    presentationPreview = mergeDefaultAppVars(
+      { ...presentationPreview, name: ' ' },
       application,
-      applicationVariables,
-    } = this.state;
+    );
 
     const previewErrors = PresentationBuilderForm.validate(
-      // We don't care about name not being provided to render
-      // the preview so hardcode a valid name.
-      { ...previewPresentation, name: ' ' },
+      presentationPreview,
       application,
       PRESENTATION_MIN_DURATION,
     );
 
-    const count = Object.keys(applicationVariables).length;
-    const nextIndex = (index + 1) % count;
-    // Setting key so the app preview reloads when index or
-    // preview mode changes.
-    const key = `${index}-${previewMode}`;
-
+    // Setting key so the app preview reloads when presentation
+    // or preview mode changes.
+    const key = `${presentationPreview.id}-${previewMode}`;
     return (
       <AppLoader
         key={key}
-        appVars={previewPresentation.application_vars}
+        appVars={presentationPreview.application_vars}
         previewErrors={previewErrors}
         enableLogs={enableLogs}
         isPresenting={present}
-        onLoad={(application, applicationVariables) => {
-          this.setStateAtIndex(index, application, applicationVariables);
-        }}
-        onComplete={() => this.setStateAtIndex(nextIndex)}
+        onLoad={this.setOptions}
+        onComplete={this.nextPresentation}
       />
     );
   }
 
   render() {
-    const { previewMode, fullScreen, presentation, application } = this.state;
+    const { previewMode, fullScreen } = this.state;
+    let { presentation, application } = this.state;
+
+    presentation = presentation || EMPTY_PRESENTATION;
+    application = application || EMPTY_APPLICATION;
+
     const containerProps = {
       onMouseOver: this.startHideControlsTimer,
       style: styles.container,
@@ -283,9 +315,9 @@ class MiraAppSimulator extends Component {
           <Container style={styles.builder}>
             <div style={styles.form}>
               <PresentationBuilderForm
-                presentation={presentation}
+                presentation={mergeDefaultAppVars(presentation, application)}
                 application={application}
-                onChange={this.setPresentation}
+                onChange={this.queuePresentationUpdate}
                 onBlur={this.flushPreviewUpdate}
                 onSubmit={() => {}}
               />

--- a/packages/mira-simulator/src/logger.js
+++ b/packages/mira-simulator/src/logger.js
@@ -1,0 +1,13 @@
+export default {
+  warning(message) {
+    console.log(`⚠️%c${message}`, 'color:#f8b91c');
+  },
+
+  pending(message) {
+    console.log(`⬜️%c${message}`, 'color:#a5a5a5');
+  },
+
+  success(message) {
+    console.log(`✅%c${message}`, 'color:#41984d');
+  },
+};

--- a/packages/mira-simulator/src/mergeDefaultAppVars.js
+++ b/packages/mira-simulator/src/mergeDefaultAppVars.js
@@ -1,0 +1,17 @@
+export default (presentation, application) => {
+  const appVars = presentation.application_vars;
+
+  application.presentation_properties.forEach(prop => {
+    if (
+      typeof prop.default !== 'undefined' &&
+      typeof appVars[prop.name] === 'undefined'
+    ) {
+      appVars[prop.name] = prop.default;
+    }
+  });
+
+  return {
+    ...presentation,
+    application_vars: appVars,
+  };
+};

--- a/packages/mira-simulator/src/preview.js
+++ b/packages/mira-simulator/src/preview.js
@@ -86,9 +86,7 @@ const requireIcon = () => {
 const icon = requireIcon();
 
 // Construct the application definition from the config file.
-const { properties, strings } = extractProperties(
-  config.presentationProperties,
-);
+const { properties, strings } = extractProperties(config.properties);
 const application = {
   name: config.name,
   icon_url: icon,
@@ -105,8 +103,8 @@ const application = {
 ReactDOM.render(
   <AppPreview
     application={application}
-    applicationVariables={config.applicationVariables}
     allowedRequestDomains={config.allowedRequestDomains}
+    simulatorOptions={config.simulator}
   >
     {props => <App {...props} />}
   </AppPreview>,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4182,7 +4182,7 @@ fancy-log@^1.1.0:
     color-support "^1.1.3"
     time-stamp "^1.0.0"
 
-fast-deep-equal@^1.0.0:
+fast-deep-equal@^1.0.0, fast-deep-equal@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz#c053477817c86b51daa853c81e059b733d023614"
 


### PR DESCRIPTION
The goal of this PR is to allow product / sales to build demos in the app playground that can be shared or linked from the website. 

**Tasks**
  - https://app.asana.com/0/486336469398975/627303490062576
  - https://app.asana.com/0/486336469398975/631525283760734

**Changes**
- Simulator now uses the query string to set presentation state
- Added a `simulator` key to for simulator-specific config in mira.config.js. This is where you define presentations now (removed `applicationVariables`).
- Fixes a couple bugs around error states. Previously, apps were not able to recover when it error'd.
- Minor css tweaks

**Previews**

I've deployed the examples with this feature so you can play around with it:
- http://mira-kit-video-example.netlify.com
- http://mira-kit-weather-example.netlify.com
- http://mira-kit-menu-example.netlify.com

**Documentation**

If you like the new mira.config.js structure I'll follow up with a documentation PR.

**FYI**

Query string characters limitations:
- IE: 2k
- Edge: 80k
- Safari: 80k
- Chrome: 100k 

https://stackoverflow.com/questions/812925/what-is-the-maximum-possible-length-of-a-query-string