### PR TITLE
Allow a custom config path to be passed in through cli

### DIFF
--- a/packages/mira-scripts/config/paths.js
+++ b/packages/mira-scripts/config/paths.js
@@ -19,10 +19,11 @@ module.exports = {
   appPackageJson: resolveApp('package.json'),
   appIcon: resolveApp('icon.svg'),
   appThumbnail: resolveApp('thumbnail.svg'),
-  appConfig: resolveApp('mira.config.js'),
   simulatorDist: path.resolve(require.resolve('mira-simulator'), '../../dist'),
 };
 
 module.exports.useYarn = fs.existsSync(
   path.join(module.exports.appPath, 'yarn.lock'),
 );
+
+module.exports.resolveApp = resolveApp;

--- a/packages/mira-scripts/config/webpack.common.js
+++ b/packages/mira-scripts/config/webpack.common.js
@@ -44,7 +44,9 @@ module.exports = {
             loader: require.resolve('eslint-loader'),
           },
         ],
-        include: [paths.appSrc],
+        // We are using appPath not appSrc to make sure we include any mira.config.js
+        // and mira.*.config.js files from the app directory.
+        include: [paths.appPath],
         exclude: [/[/\\\\]node_modules[/\\\\]/],
       },
       {
@@ -67,7 +69,9 @@ module.exports = {
           // Process application JS with Babel.
           {
             test: /\.(js|jsx|mjs)$/,
-            include: [paths.appSrc],
+            // We are using appPath not appSrc to make sure we include any mira.config.js
+            // and mira.*.config.js files from the app directory.
+            include: [paths.appPath],
             exclude: [/[/\\\\]node_modules[/\\\\]/],
             loader: require.resolve('babel-loader'),
             options: {

--- a/packages/mira-scripts/config/webpack.preview.config.js
+++ b/packages/mira-scripts/config/webpack.preview.config.js
@@ -8,67 +8,70 @@ const paths = require('./paths');
 const common = require('./webpack.common');
 const getClientEnvironment = require('./env');
 
-const env = getClientEnvironment({
-  MIRA_SIMULATOR_APP_INDEX_PATH: paths.appIndexJs,
-  MIRA_SIMULATOR_APP_CONFIG_PATH: paths.appConfig,
-  MIRA_SIMULATOR_APP_ICON_PATH: fs.existsSync(paths.appIcon)
-    ? paths.appIcon
-    : '',
-});
+module.exports = (relConfigPath = 'mira.config.js') => {
+  const configPath = paths.resolveApp(relConfigPath);
+  const env = getClientEnvironment({
+    MIRA_SIMULATOR_APP_INDEX_PATH: paths.appIndexJs,
+    MIRA_SIMULATOR_APP_CONFIG_PATH: configPath,
+    MIRA_SIMULATOR_APP_ICON_PATH: fs.existsSync(paths.appIcon)
+      ? paths.appIcon
+      : '',
+  });
 
-module.exports = {
-  devtool: 'cheap-module-source-map',
-  entry: [
-    // Development polyfills (mainly for promise rejection tracking).
-    require.resolve('./polyfills'),
-    // Enables auto reload.
-    require.resolve('react-dev-utils/webpackHotDevClient'),
-    // The simulator entry, the app path to load is set with
-    // the MIRA_SIMULATOR_APP_PATH environment variable.
-    require.resolve('mira-simulator/preview'),
-  ],
-  output: {
-    // Add /* filename */ comments to generated require()s in the output.
-    pathinfo: true,
-    filename: 'bundle.js',
-    // Point sourcemap entries to original disk location (format as URL on Windows)
-    devtoolModuleFilenameTemplate: info =>
-      path.resolve(info.absoluteResourcePath).replace(/\\/g, '/'),
-  },
-  resolve: {
-    ...common.resolve,
-  },
-  module: {
-    ...common.module,
-  },
-  plugins: [
-    // Generates an `index.html` file with the <script> injected.
-    new HtmlWebpackPlugin({
-      inject: true,
-      template: require.resolve('mira-simulator/preview.html'),
-    }),
-    // Add module names to factory functions so they appear in browser profiler.
-    new webpack.NamedModulesPlugin(),
-    // Makes some environment variables available to the JS code.
-    new webpack.DefinePlugin(env.stringified),
-    // This is necessary to emit hot updates (currently CSS only):
-    new webpack.HotModuleReplacementPlugin(),
-    // Watcher doesn't work well if you mistype casing in a path so we use
-    // a plugin that prints an error when you attempt to do this.
-    new CaseSensitivePathsPlugin(),
-    // If you require a missing module and then `npm install` it, you still have
-    // to restart the development server for Webpack to discover it. This plugin
-    // makes the discovery automatic so you don't have to restart.
-    new WatchMissingNodeModulesPlugin(paths.appNodeModules),
-    ...common.plugins,
-  ],
-  node: {
-    ...common.node,
-  },
-  // Turn off performance hints during development because we don't do any
-  // splitting or minification in interest of speed. These warnings become
-  // cumbersome.
-  performance: {
-    hints: false,
-  },
+  return {
+    devtool: 'cheap-module-source-map',
+    entry: [
+      // Development polyfills (mainly for promise rejection tracking).
+      require.resolve('./polyfills'),
+      // Enables auto reload.
+      require.resolve('react-dev-utils/webpackHotDevClient'),
+      // The simulator entry, the app path to load is set with
+      // the MIRA_SIMULATOR_APP_PATH environment variable.
+      require.resolve('mira-simulator/preview'),
+    ],
+    output: {
+      // Add /* filename */ comments to generated require()s in the output.
+      pathinfo: true,
+      filename: 'bundle.js',
+      // Point sourcemap entries to original disk location (format as URL on Windows)
+      devtoolModuleFilenameTemplate: info =>
+        path.resolve(info.absoluteResourcePath).replace(/\\/g, '/'),
+    },
+    resolve: {
+      ...common.resolve,
+    },
+    module: {
+      ...common.module,
+    },
+    plugins: [
+      // Generates an `index.html` file with the <script> injected.
+      new HtmlWebpackPlugin({
+        inject: true,
+        template: require.resolve('mira-simulator/preview.html'),
+      }),
+      // Add module names to factory functions so they appear in browser profiler.
+      new webpack.NamedModulesPlugin(),
+      // Makes some environment variables available to the JS code.
+      new webpack.DefinePlugin(env.stringified),
+      // This is necessary to emit hot updates (currently CSS only):
+      new webpack.HotModuleReplacementPlugin(),
+      // Watcher doesn't work well if you mistype casing in a path so we use
+      // a plugin that prints an error when you attempt to do this.
+      new CaseSensitivePathsPlugin(),
+      // If you require a missing module and then `npm install` it, you still have
+      // to restart the development server for Webpack to discover it. This plugin
+      // makes the discovery automatic so you don't have to restart.
+      new WatchMissingNodeModulesPlugin(paths.appNodeModules),
+      ...common.plugins,
+    ],
+    node: {
+      ...common.node,
+    },
+    // Turn off performance hints during development because we don't do any
+    // splitting or minification in interest of speed. These warnings become
+    // cumbersome.
+    performance: {
+      hints: false,
+    },
+  };
 };

--- a/packages/mira-scripts/config/webpack.prod.config.js
+++ b/packages/mira-scripts/config/webpack.prod.config.js
@@ -6,42 +6,44 @@ const paths = require('./paths');
 const common = require('./webpack.common');
 const getClientEnvironment = require('./env');
 
-const env = getClientEnvironment();
-
-module.exports = {
-  // Don't attempt to continue if there are any errors.
-  bail: true,
-  devtool: 'source-map',
-  entry: {
-    bundle: paths.appIndexJs,
-    'mira.config': paths.appConfig,
-  },
-  output: {
-    // The build folder.
-    path: paths.appBuild,
-    filename: '[name].js',
-    // Point sourcemap entries to original disk location (format as URL on Windows)
-    devtoolModuleFilenameTemplate: info =>
-      path.resolve(info.absoluteResourcePath).replace(/\\/g, '/'),
-  },
-  externals: {
-    // React is injected into Mira apps in the dashboard and on the device.
-    react: 'React',
-  },
-  resolve: {
-    ...common.resolve,
-  },
-  module: {
-    ...common.module,
-  },
-  plugins: [
-    new webpack.DefinePlugin(env.stringified),
-    new CopyWebpackPlugin([paths.appIcon, paths.appThumbnail]),
-    // Compresses icon.svg, thumbnail.svg.
-    new ImageminPlugin({ test: /\.(jpe?g|png|gif|svg)$/i }),
-    ...common.plugins,
-  ],
-  node: {
-    ...common.node,
-  },
+module.exports = (relConfigPath = 'mira.config.js') => {
+  const env = getClientEnvironment();
+  const configPath = paths.resolveApp(relConfigPath);
+  return {
+    // Don't attempt to continue if there are any errors.
+    bail: true,
+    devtool: 'source-map',
+    entry: {
+      bundle: paths.appIndexJs,
+      'mira.config': configPath,
+    },
+    output: {
+      // The build folder.
+      path: paths.appBuild,
+      filename: '[name].js',
+      // Point sourcemap entries to original disk location (format as URL on Windows)
+      devtoolModuleFilenameTemplate: info =>
+        path.resolve(info.absoluteResourcePath).replace(/\\/g, '/'),
+    },
+    externals: {
+      // React is injected into Mira apps in the dashboard and on the device.
+      react: 'React',
+    },
+    resolve: {
+      ...common.resolve,
+    },
+    module: {
+      ...common.module,
+    },
+    plugins: [
+      new webpack.DefinePlugin(env.stringified),
+      new CopyWebpackPlugin([paths.appIcon, paths.appThumbnail]),
+      // Compresses icon.svg, thumbnail.svg.
+      new ImageminPlugin({ test: /\.(jpe?g|png|gif|svg)$/i }),
+      ...common.plugins,
+    ],
+    node: {
+      ...common.node,
+    },
+  };
 };

--- a/packages/mira-scripts/config/webpack.static.config.js
+++ b/packages/mira-scripts/config/webpack.static.config.js
@@ -8,79 +8,88 @@ const paths = require('./paths');
 const common = require('./webpack.common');
 const getClientEnvironment = require('./env');
 
-const env = getClientEnvironment({
-  MIRA_SIMULATOR_APP_INDEX_PATH: paths.appIndexJs,
-  MIRA_SIMULATOR_APP_CONFIG_PATH: paths.appConfig,
-  MIRA_SIMULATOR_APP_ICON_PATH: fs.existsSync(paths.appIcon)
-    ? paths.appIcon
-    : '',
-});
+module.exports = (relConfigPath = 'mira.config.js') => {
+  const configPath = paths.resolveApp(relConfigPath);
+  const env = getClientEnvironment({
+    MIRA_SIMULATOR_APP_INDEX_PATH: paths.appIndexJs,
+    MIRA_SIMULATOR_APP_CONFIG_PATH: configPath,
+    MIRA_SIMULATOR_APP_ICON_PATH: fs.existsSync(paths.appIcon)
+      ? paths.appIcon
+      : '',
+  });
 
-module.exports = {
-  devtool: 'cheap-module-source-map',
-  entry: require.resolve('mira-simulator/preview'),
-  output: {
-    path: paths.appStaticPreview,
-    filename: 'bundle.js',
-    // Point sourcemap entries to original disk location (format as URL on Windows)
-    devtoolModuleFilenameTemplate: info =>
-      path.resolve(info.absoluteResourcePath).replace(/\\/g, '/'),
-  },
-  resolve: {
-    ...common.resolve,
-  },
-  module: {
-    ...common.module,
-  },
-  plugins: [
-    // Generates an `index.html` file with the <script> injected.
-    new HtmlWebpackPlugin({
-      inject: true,
-      template: require.resolve('mira-simulator/preview.html'),
-    }),
-    // Makes some environment variables available to the JS code.
-    new webpack.DefinePlugin(env.stringified),
-    new CopyWebpackPlugin([
-      // Copy files to static preview directory.
-      ...(fs.existsSync(paths.appFiles)
-        ? [{ from: paths.appFiles, to: paths.appStaticPreview, flatten: true }]
-        : []),
-      // Copy the simulator bundle to the root static directory.
-      { from: paths.simulatorDist, to: paths.appStatic },
-    ]),
-    // Common plugins.
-    ...common.plugins,
-    // Minify.
-    new UglifyJsPlugin({
-      uglifyOptions: {
-        ecma: 8,
-        compress: {
-          warnings: false,
-          // Disabled because of an issue with Uglify breaking seemingly valid code:
-          // https://github.com/facebook/create-react-app/issues/2376
-          // Pending further investigation:
-          // https://github.com/mishoo/UglifyJS2/issues/2011
-          comparisons: false,
+  return {
+    devtool: 'cheap-module-source-map',
+    entry: require.resolve('mira-simulator/preview'),
+    output: {
+      path: paths.appStaticPreview,
+      filename: 'bundle.js',
+      // Point sourcemap entries to original disk location (format as URL on Windows)
+      devtoolModuleFilenameTemplate: info =>
+        path.resolve(info.absoluteResourcePath).replace(/\\/g, '/'),
+    },
+    resolve: {
+      ...common.resolve,
+    },
+    module: {
+      ...common.module,
+    },
+    plugins: [
+      // Generates an `index.html` file with the <script> injected.
+      new HtmlWebpackPlugin({
+        inject: true,
+        template: require.resolve('mira-simulator/preview.html'),
+      }),
+      // Makes some environment variables available to the JS code.
+      new webpack.DefinePlugin(env.stringified),
+      new CopyWebpackPlugin([
+        // Copy files to static preview directory.
+        ...(fs.existsSync(paths.appFiles)
+          ? [
+              {
+                from: paths.appFiles,
+                to: paths.appStaticPreview,
+                flatten: true,
+              },
+            ]
+          : []),
+        // Copy the simulator bundle to the root static directory.
+        { from: paths.simulatorDist, to: paths.appStatic },
+      ]),
+      // Common plugins.
+      ...common.plugins,
+      // Minify.
+      new UglifyJsPlugin({
+        uglifyOptions: {
+          ecma: 8,
+          compress: {
+            warnings: false,
+            // Disabled because of an issue with Uglify breaking seemingly valid code:
+            // https://github.com/facebook/create-react-app/issues/2376
+            // Pending further investigation:
+            // https://github.com/mishoo/UglifyJS2/issues/2011
+            comparisons: false,
+          },
+          mangle: {
+            safari10: true,
+          },
+          output: {
+            comments: false,
+            // Turned on because emoji and regex is not minified properly using default
+            // https://github.com/facebook/create-react-app/issues/2488
+            ascii_only: true,
+          },
         },
-        mangle: {
-          safari10: true,
-        },
-        output: {
-          comments: false,
-          // Turned on because emoji and regex is not minified properly using default
-          // https://github.com/facebook/create-react-app/issues/2488
-          ascii_only: true,
-        },
-      },
-      // Use multi-process parallel running to improve the build speed
-      // Default number of concurrent runs: os.cpus().length - 1
-      parallel: true,
-      // Enable file caching
-      cache: true,
-      sourceMap: true,
-    }),
-  ],
-  node: {
-    ...common.node,
-  },
+        // Use multi-process parallel running to improve the build speed
+        // Default number of concurrent runs: os.cpus().length - 1
+        parallel: true,
+        // Enable file caching
+        cache: true,
+        sourceMap: true,
+      }),
+    ],
+    node: {
+      ...common.node,
+    },
+  };
 };

--- a/packages/mira-scripts/scripts/build.js
+++ b/packages/mira-scripts/scripts/build.js
@@ -11,6 +11,7 @@ process.on('unhandledRejection', err => {
 
 const chalk = require('chalk');
 const fs = require('fs-extra');
+const argv = require('minimist')(process.argv.slice(2));
 const {
   measureFileSizesBeforeBuild,
   printFileSizesAfterBuild,
@@ -19,7 +20,7 @@ const formatWebpackMessages = require('react-dev-utils/formatWebpackMessages');
 const printBuildError = require('react-dev-utils/printBuildError');
 const promisify = require('util.promisify');
 const webpack = require('webpack');
-const config = require('../config/webpack.prod.config');
+const createConfig = require('../config/webpack.prod.config');
 const paths = require('../config/paths');
 
 const isCI =
@@ -27,11 +28,13 @@ const isCI =
   (typeof process.env.CI !== 'string' ||
     process.env.CI.toLowerCase() !== 'false');
 
+const configPath = argv.config;
+
 async function build() {
   const previousFileSizes = await measureFileSizesBeforeBuild(paths.appBuild);
   // Clean build directory.
   fs.emptyDirSync(paths.appBuild);
-  const compiler = webpack(config);
+  const compiler = webpack(createConfig(configPath));
   const runCompiler = promisify(compiler.run.bind(compiler));
   try {
     console.log('Creating production build...');

--- a/packages/mira-scripts/scripts/start.js
+++ b/packages/mira-scripts/scripts/start.js
@@ -10,6 +10,7 @@ process.on('unhandledRejection', err => {
 });
 
 const chalk = require('chalk');
+const argv = require('minimist')(process.argv.slice(2));
 const clearConsole = require('react-dev-utils/clearConsole');
 const openBrowser = require('react-dev-utils/openBrowser');
 const {
@@ -20,13 +21,14 @@ const {
 const webpack = require('webpack');
 const WebpackDevServer = require('webpack-dev-server');
 const paths = require('../config/paths');
-const config = require('../config/webpack.preview.config');
+const createConfig = require('../config/webpack.preview.config');
 const createDevServerConfig = require('../config/webpackDevServer.config');
 
 const defaultPort = parseInt(process.env.PORT, 10) || 3000;
 const host = process.env.HOST || '0.0.0.0';
 const protocol = process.env.HTTPS === 'true' ? 'https' : 'http';
 const isInteractive = process.stdout.isTTY;
+const configPath = argv.config;
 
 async function start() {
   const appName = require(paths.appPackageJson).name;
@@ -34,7 +36,7 @@ async function start() {
   const urls = prepareUrls(protocol, host, port);
   const compiler = createCompiler(
     webpack,
-    config,
+    createConfig(configPath),
     appName,
     urls,
     paths.useYarn,

--- a/packages/mira-scripts/scripts/static.js
+++ b/packages/mira-scripts/scripts/static.js
@@ -11,11 +11,12 @@ process.on('unhandledRejection', err => {
 
 const chalk = require('chalk');
 const fs = require('fs-extra');
+const argv = require('minimist')(process.argv.slice(2));
 const formatWebpackMessages = require('react-dev-utils/formatWebpackMessages');
 const printBuildError = require('react-dev-utils/printBuildError');
 const promisify = require('util.promisify');
 const webpack = require('webpack');
-const config = require('../config/webpack.static.config');
+const createConfig = require('../config/webpack.static.config');
 const paths = require('../config/paths');
 
 const isCI =
@@ -23,10 +24,12 @@ const isCI =
   (typeof process.env.CI !== 'string' ||
     process.env.CI.toLowerCase() !== 'false');
 
+const configPath = argv.config;
+
 async function build() {
   // Clean build directory.
   fs.emptyDirSync(paths.appStatic);
-  const compiler = webpack(config);
+  const compiler = webpack(createConfig(configPath));
   const runCompiler = promisify(compiler.run.bind(compiler));
   try {
     console.log('Creating static build...');


### PR DESCRIPTION
https://app.asana.com/0/486336469398975/635494728174321

Not unlike how webpack allows you to use different config for environments.

Will be a hidden feature for now but we'll use this to deploy the static build with empty simulator presentations for demos. 

```bash
yarn static --config mira.demo.config.js
```

```js
// mira.demo.config.js
import config from './mira.config'
export default {
   ...config,
   simulator: { presentations: [] }
}

```
