### PR TITLE
Don't throw sandbox errors for webpack hot reload or other dev dependencies

### DIFF
--- a/packages/mira-simulator/src/AppPreview.js
+++ b/packages/mira-simulator/src/AppPreview.js
@@ -8,18 +8,6 @@ import {
 import createMessenger from './createMessenger';
 import { EventEmitter } from 'eventemitter3';
 
-// Private fetch used for fetching in mira resources.
-const privateFetch = window.fetch.bind(window);
-
-// Clobber XMLHttpRequest because it is not available in the Mira sandbox.
-window.XMLHttpRequest = captureSandboxFailure(
-  'XMLHttpRequest',
-  'miraRequestResource',
-);
-
-// Clobber fetch because it is not available on MiraLinks
-window.fetch = captureSandboxFailure('fetch', 'miraRequestResource');
-
 class AppPreview extends Component {
   static propTypes = {
     application: PropTypes.object.isRequired,
@@ -34,6 +22,20 @@ class AppPreview extends Component {
 
   state = {};
   miraEvents = new EventEmitter();
+
+  componentWillMount() {
+    // Private fetch used for fetching in mira resources.
+    this.privateFetch = window.fetch.bind(window);
+
+    // Clobber XMLHttpRequest because it is not available in the Mira sandbox.
+    window.XMLHttpRequest = captureSandboxFailure(
+      'XMLHttpRequest',
+      'miraRequestResource',
+    );
+
+    // Clobber fetch because it is not available on MiraLinks.
+    window.fetch = captureSandboxFailure('fetch', 'miraRequestResource');
+  }
 
   componentDidMount() {
     const { application, simulatorOptions } = this.props;
@@ -77,9 +79,9 @@ class AppPreview extends Component {
     const props = {
       ...this.state.appVars,
       miraEvents: this.miraEvents,
-      miraFileResource: createFileResource(privateFetch),
+      miraFileResource: createFileResource(this.privateFetch),
       miraRequestResource: createRequestResource(
-        privateFetch,
+        this.privateFetch,
         this.props.allowedRequestDomains,
       ),
     };


### PR DESCRIPTION
Ran into this weird issue trying to deploy the news demo app. It seems that depending on the order in which webpack bundles dependencies the simulator can end up throwing sandbox errors for external dependencies. 

The error doesn't seem to surface in chrome locally but it does when deploying the static build. Firefox always has the error, even in local dev.

I tracked it down to webpack hot reload locally but it's not included in the static deploy. From what I can tell there's an internal lib webpack uses to test for the existence of `XMLHttpRequest`. Testing for it throws the error.

This PR changes the timing of when the sandbox is created to allow any dev dependencies to access `XMLHTTPRequest` or `fetch`. I've confirmed that the error is still thrown if you use `fetch` inside the actual app. 