### PR TITLE
Use presentation prop instead of merging application vars into props

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -75,13 +75,13 @@ The entry file for Mira apps is `src/index.js` and it must export your app wrapp
 import { withMiraApp } from 'mira-kit';
 
 const App = ({
+  presentation,
   isPlaying,
   playCount,
   onReady,
   onComplete,
   onError,
   miraRequestResource,
-  ...presentationValues
 }) => {
   // ...
 };
@@ -93,6 +93,7 @@ Wrapping your app in `withMiraApp` will inject these props into your app.
 
 | Prop                | Type       | Definition                                                                                                                                                                                                                 |
 | ------------------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| presentation        | `object`   | An instance of your application with the user-defined name and values.<br/>ie. `{ name: 'Weather', values: { city: 'San Francisco' } }`                                                                                    |
 | isPlaying           | `boolean`  | Starts at `false` and becomes `true` when your app is visible.                                                                                                                                                             |
 | playCount           | `number`   | Starts at `0` and increments on every play when your app is looping.                                                                                                                                                       |
 | onReady             | `function` | Call this when your app is ready to be displayed, typically after fetching initial data.                                                                                                                                   |
@@ -252,22 +253,21 @@ export default {
 };
 ```
 
-Presentation values are injected into your app:
+The active presentation is injected into your app's props:
 
 ```js
 // src/index.js
 import { withMiraApp } from 'mira-kit';
 
-const Weather = ({
-  isPlaying,
-  onReady,
-  onComplete,
-  onError,
-  // Presentation values.
-  city,
-  units,
-  duration,
-}) => {
+const Weather = ({ presentation, isPlaying, onReady, onComplete, onError }) => {
+  // presentation = {
+  //   name: 'San Francisco',
+  //   values: {
+  //     city: 'San Francisco, CA',
+  //     units: 'imperial',
+  //     duration: 10,
+  //   }
+  // }
   // ...
 };
 
@@ -299,8 +299,8 @@ import React from 'react';
 import { withMiraApp } from 'mira-kit';
 
 // Render the image and call onReady when it has loaded.
-const PictureApp = ({ image, onReady }) => (
-  <img src={image.url} onLoad={onReady} />
+const PictureApp = ({ presentation, onReady }) => (
+  <img src={presentation.values.image.url} onLoad={onReady} />
 );
 
 export default withMiraApp(PictureApp);
@@ -353,10 +353,10 @@ class WeatherApp extends Component {
   }
 
   await fetchWeatherData() {
-    const { city, miraRequestResource, onReady, onError } = this.props;
+    const { presentation, miraRequestResource, onReady, onError } = this.props;
     try {
       const url = `https://api.weather.com/${city}`;
-      const response = await miraRequestResource(url);
+      const response = await miraRequestResource(presentation.values.url);
       const weatherData = await response.json();
       this.setState({ weatherData });
       // Calling onReady will let the runtime know your

--- a/examples/menu/src/index.js
+++ b/examples/menu/src/index.js
@@ -5,23 +5,27 @@ import './styles.css';
 
 class Menu extends Component {
   static propTypes = {
+    presentation: PropTypes.shape({
+      values: PropTypes.shape({
+        categories: PropTypes.arrayOf(
+          PropTypes.shape({
+            name: PropTypes.string.isRequired,
+            items: PropTypes.arrayOf(
+              PropTypes.shape({
+                name: PropTypes.string.isRequired,
+                itemDescription: PropTypes.string.isRequired,
+                price: PropTypes.string.isRequired,
+              }),
+            ),
+          }),
+        ),
+        duration: PropTypes.number.isRequired,
+      }),
+    }).isRequired,
     isPlaying: PropTypes.bool.isRequired,
     onReady: PropTypes.func.isRequired,
     onComplete: PropTypes.func.isRequired,
     onError: PropTypes.func.isRequired,
-    categories: PropTypes.arrayOf(
-      PropTypes.shape({
-        name: PropTypes.string.isRequired,
-        items: PropTypes.arrayOf(
-          PropTypes.shape({
-            name: PropTypes.string.isRequired,
-            itemDescription: PropTypes.string.isRequired,
-            price: PropTypes.string.isRequired,
-          }),
-        ),
-      }),
-    ),
-    duration: PropTypes.number.isRequired,
   };
 
   componentDidMount() {
@@ -30,17 +34,20 @@ class Menu extends Component {
   }
 
   componentDidUpdate() {
-    const { isPlaying, duration, onComplete } = this.props;
+    const { isPlaying, presentation, onComplete } = this.props;
     if (isPlaying) {
       clearTimeout(this.onCompleteTimeout);
-      this.onCompleteTimeout = setTimeout(onComplete, duration * 1000);
+      this.onCompleteTimeout = setTimeout(
+        onComplete,
+        presentation.values.duration * 1000,
+      );
     }
   }
 
   render() {
-    const { isPlaying, categories = [] } = this.props;
+    const { isPlaying, presentation } = this.props;
+    const categories = presentation.values.categories || [];
     const isPortrait = document.body.clientHeight > document.body.clientWidth;
-
     return (
       <div className={`container${isPortrait ? ' portrait' : ''}`}>
         {categories.map((category, i) => (

--- a/examples/video-player/src/index.js
+++ b/examples/video-player/src/index.js
@@ -3,8 +3,7 @@ import { withMiraApp } from 'mira-kit';
 import './styles.css';
 
 const VideoPlayer = ({
-  video,
-  mute,
+  presentation,
   isPlaying,
   onReady,
   onComplete,
@@ -17,8 +16,8 @@ const VideoPlayer = ({
         videoEl.play();
       }
     }}
-    src={video.url}
-    muted={mute}
+    src={presentation.values.video.url}
+    muted={presentation.values.mute}
     onCanPlay={onReady}
     onEnded={onComplete}
     onError={e => onError(new Error(`Media error: ${e.target.error.code}`))}

--- a/examples/weather/src/index.js
+++ b/examples/weather/src/index.js
@@ -8,8 +8,13 @@ const apiKey = process.env.MIRA_APP_OPENWEATHERMAP_API_KEY;
 
 class Weather extends Component {
   static propTypes = {
-    city: PropTypes.string.isRequired,
-    units: PropTypes.oneOf(['imperial', 'metric']).isRequired,
+    presentation: PropTypes.shape({
+      values: PropTypes.shape({
+        city: PropTypes.string.isRequired,
+        units: PropTypes.oneOf(['imperial', 'metric']).isRequired,
+        duration: PropTypes.number.isRequired,
+      }),
+    }).isRequired,
     isPlaying: PropTypes.bool.isRequired,
     onReady: PropTypes.func.isRequired,
     onComplete: PropTypes.func.isRequired,
@@ -26,9 +31,13 @@ class Weather extends Component {
   }
 
   async componentDidUpdate(prevProps) {
-    const { city, units, duration, isPlaying, onComplete } = this.props;
+    const { presentation, isPlaying, onComplete } = this.props;
+    const { city, units, duration } = presentation.values;
     // Re-fetch weather data when props change.
-    if (prevProps.city !== city || prevProps.units !== units) {
+    if (
+      prevProps.presentation.values.city !== city ||
+      prevProps.presentation.values.units !== units
+    ) {
       await this.fetchWeatherData();
     }
     // Start onComplete timeout when app becomes visible.
@@ -44,8 +53,8 @@ class Weather extends Component {
   }
 
   async fetchWeatherData() {
-    const { city, units, miraRequestResource, onReady, onError } = this.props;
-
+    const { presentation, miraRequestResource, onReady, onError } = this.props;
+    const { city, units } = presentation.values;
     try {
       const response = await miraRequestResource(
         `${apiUrl}?q=${city}&units=${units}&appid=${apiKey}`,

--- a/packages/mira-kit/src/withMiraApp.js
+++ b/packages/mira-kit/src/withMiraApp.js
@@ -14,6 +14,10 @@ export default App => {
     static displayName = `withMiraApp(${appName || 'App'})`;
 
     static propTypes = {
+      presentation: PropTypes.shape({
+        name: PropTypes.string.isRequired,
+        application_vars: PropTypes.object.isRequired,
+      }).isRequired,
       miraEvents: PropTypes.shape({
         on: PropTypes.func.isRequired,
         emit: PropTypes.func.isRequired,
@@ -74,6 +78,7 @@ export default App => {
     };
 
     handlePresentationError = error => {
+      const { presentation } = this.props;
       // Fire presentation complete immediately if we are currently playing.
       // Otherwise, fire presentation_ready so that play is triggered.
       if (this.state.isPlaying) {
@@ -86,9 +91,17 @@ export default App => {
       this.setState({ error });
 
       console.error(
-        `App ${appName ? `'${appName}' ` : ''}errored: ${error.message}`,
+        `Presentation error for '${presentation.name}': ${error.message}`,
       );
     };
+
+    getPresentation() {
+      const { presentation } = this.props;
+      return {
+        name: presentation.name,
+        values: presentation.application_vars,
+      };
+    }
 
     render() {
       const { error, isPlaying, playCount } = this.state;
@@ -107,12 +120,13 @@ export default App => {
         miraFileResource,
         miraRequestResource,
         strings,
-        ...appProps
+        ...legacyApplicationVars
       } = this.props;
 
       return (
         <App
-          {...appProps}
+          {...legacyApplicationVars}
+          presentation={this.getPresentation()}
           isPlaying={isPlaying}
           playCount={playCount}
           onReady={this.handlePresentationReady}

--- a/packages/mira-kit/src/withMiraApp.test.js
+++ b/packages/mira-kit/src/withMiraApp.test.js
@@ -9,7 +9,12 @@ const createProps = () => ({
   miraRequestResource: () => Promise.resolve,
   miraFileResource: () => Promise.resolve,
   strings: { string: 'string' },
-  appProp: 'appProp',
+  presentation: {
+    name: 'presentation',
+    application_vars: {
+      foo: 'bar',
+    },
+  },
 });
 
 const App = () => <div />;
@@ -22,7 +27,10 @@ test('Should render app', () => {
   expect(app.length).toEqual(1);
   const appProps = app.props();
   expect(Object.keys(appProps).length).toEqual(9);
-  expect(appProps.appProp).toEqual(props.appProp);
+  expect(appProps.presentation.name).toEqual(props.presentation.name);
+  expect(appProps.presentation.values).toEqual(
+    props.presentation.application_vars,
+  );
   expect(appProps.isPlaying).toEqual(false);
   expect(appProps.playCount).toEqual(0);
   expect(typeof appProps.onReady).toEqual('function');

--- a/packages/mira-simulator/src/AppLoader.js
+++ b/packages/mira-simulator/src/AppLoader.js
@@ -6,7 +6,10 @@ import logger from './logger';
 
 class AppLoader extends Component {
   static propTypes = {
-    appVars: PropTypes.object.isRequired,
+    presentation: PropTypes.shape({
+      name: PropTypes.string,
+      application_vars: PropTypes.object,
+    }).isRequired,
     onLoad: PropTypes.func.isRequired,
     onComplete: PropTypes.func,
     enableLogs: PropTypes.bool,
@@ -27,7 +30,7 @@ class AppLoader extends Component {
     didReceiveReady: false,
   };
 
-  hasSentInitialAppVars = false;
+  hasSentInitialPresentation = false;
 
   componentDidMount() {
     this.messenger = createMessenger(
@@ -44,18 +47,18 @@ class AppLoader extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { appVars } = this.props;
+    const { presentation } = this.props;
     if (!this.checkPreviewErrors()) {
       // Send app vars if:
       //  - There are no errors.
       //  - We have not sent the initial app vars since load.
       //  - They have changed.
       if (
-        !this.hasSentInitialAppVars ||
-        !deepEqual(appVars, prevProps.appVars)
+        !this.hasSentInitialPresentation ||
+        !deepEqual(presentation, prevProps.presentation)
       ) {
-        this.messenger.send('application_variables', appVars);
-        this.hasSentInitialAppVars = true;
+        this.messenger.send('presentation', presentation);
+        this.hasSentInitialPresentation = true;
       }
       // Only log once.
       if (!this.hasLoggedReady) {
@@ -69,7 +72,7 @@ class AppLoader extends Component {
     const { isPresenting, onComplete } = this.props;
 
     if (type === 'init') {
-      this.hasSentInitialAppVars = false;
+      this.hasSentInitialPresentation = false;
       this.props.onLoad(payload.application, payload.simulatorOptions);
     } else if (type === 'presentation_ready') {
       this.logSuccess('onReady received.');

--- a/packages/mira-simulator/src/AppPreview.js
+++ b/packages/mira-simulator/src/AppPreview.js
@@ -20,7 +20,10 @@ class AppPreview extends Component {
     simulatorOptions: { presentations: [] },
   };
 
-  state = {};
+  state = {
+    presentation: null,
+  };
+
   miraEvents = new EventEmitter();
 
   componentWillMount() {
@@ -67,26 +70,32 @@ class AppPreview extends Component {
   receiveMessage = (type, payload) => {
     if (type === 'play') {
       this.miraEvents.emit('play');
-    } else if (type === 'application_variables') {
-      this.setState({ appVars: payload });
+    } else if (type === 'presentation') {
+      this.setState({ presentation: payload });
     }
   };
 
   render() {
-    // Don't render the app if we haven't received any app vars yet.
-    if (!this.state.appVars) return null;
+    const { allowedRequestDomains, children } = this.props;
+    const { presentation } = this.state;
+    // Don't render the app if we haven't received the presentation object yet.
+    if (!presentation) return null;
+    // Spreading app props will be deprecated. New apps should use the presentation
+    // prop which contains the application variables.
+    const legacyApplicationVars = presentation.application_vars;
 
     const props = {
-      ...this.state.appVars,
+      ...legacyApplicationVars,
+      presentation,
       miraEvents: this.miraEvents,
       miraFileResource: createFileResource(this.privateFetch),
       miraRequestResource: createRequestResource(
         this.privateFetch,
-        this.props.allowedRequestDomains,
+        allowedRequestDomains,
       ),
     };
 
-    return this.props.children(props);
+    return children(props);
   }
 }
 

--- a/packages/mira-simulator/src/Simulator.js
+++ b/packages/mira-simulator/src/Simulator.js
@@ -262,7 +262,7 @@ class MiraAppSimulator extends Component {
     // We don't care about name not being set to render the preview
     // so we hard-code a valid name.
     presentationPreview = mergeDefaultAppVars(
-      { ...presentationPreview, name: ' ' },
+      { ...presentationPreview, name: presentationPreview.name || ' ' },
       application,
     );
 
@@ -278,7 +278,7 @@ class MiraAppSimulator extends Component {
     return (
       <AppLoader
         key={key}
-        appVars={presentationPreview.application_vars}
+        presentation={presentationPreview}
         previewErrors={previewErrors}
         enableLogs={enableLogs}
         isPresenting={present}


### PR DESCRIPTION
Avoid conflicts when merging user defined application variables with platform props. Passes down a presentation prop instead of spreading application_variables onto props. 

This also allows us to use the name of the presentation for better logging.

Also sets us up for themes.