### PR TITLE
Update to React 16

### DIFF
--- a/examples/menu/package.json
+++ b/examples/menu/package.json
@@ -7,8 +7,8 @@
     "mira-scripts": "^3.1.0",
     "netlify-cli": "^1.2.2",
     "prop-types": "^15.6.1",
-    "react": "^15.6.0",
-    "react-dom": "^15.6.0"
+    "react": "^16.4.0",
+    "react-dom": "^16.4.0"
   },
   "scripts": {
     "start": "mira-scripts start",

--- a/examples/video-player/package.json
+++ b/examples/video-player/package.json
@@ -7,8 +7,8 @@
     "mira-scripts": "^3.1.0",
     "netlify-cli": "^1.2.2",
     "prop-types": "^15.6.1",
-    "react": "^15.6.0",
-    "react-dom": "^15.6.0"
+    "react": "^16.4.0",
+    "react-dom": "^16.4.0"
   },
   "scripts": {
     "start": "mira-scripts start",

--- a/examples/weather/package.json
+++ b/examples/weather/package.json
@@ -7,8 +7,8 @@
     "mira-scripts": "^3.1.0",
     "netlify-cli": "^1.2.2",
     "prop-types": "^15.6.1",
-    "react": "^15.6.0",
-    "react-dom": "^15.6.0"
+    "react": "^16.4.0",
+    "react-dom": "^16.4.0"
   },
   "scripts": {
     "start": "mira-scripts start",

--- a/packages/mira-kit/package.json
+++ b/packages/mira-kit/package.json
@@ -11,8 +11,8 @@
   "files": ["lib", "prop-types.js", "typings.d.ts"],
   "dependencies": {
     "prop-types": "^15.6.1",
-    "react": "^15.6.0",
-    "react-dom": "^15.6.0"
+    "react": "^16.4.0",
+    "react-dom": "^16.4.0"
   },
   "devDependencies": {
     "@babel/cli": "7.0.0-beta.42",
@@ -21,11 +21,11 @@
     "babel-jest": "22.1.0",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
     "babel-preset-react-app": "next",
-    "enzyme": "^3.2.0",
-    "enzyme-adapter-react-15": "^1.0.5",
+    "enzyme": "^3.3.0",
+    "enzyme-adapter-react-16": "^1.1.1",
     "eventemitter3": "^3.0.1",
     "jest": "^22.4.2",
-    "react-test-renderer": "^15.6.1"
+    "react-test-renderer": "^16.4.0"
   },
   "babel": {
     "presets": ["react-app"],

--- a/packages/mira-kit/src/setupTests.js
+++ b/packages/mira-kit/src/setupTests.js
@@ -1,5 +1,5 @@
 import { configure } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-15';
+import Adapter from 'enzyme-adapter-react-16';
 
 // Supress console errors during tests.
 global.console.error = () => {};

--- a/packages/mira-scripts/scripts/init.js
+++ b/packages/mira-scripts/scripts/init.js
@@ -70,8 +70,10 @@ module.exports = (appPath, appName, verbose, originalDirectory) => {
     }
   }
 
-  const dependencies = ['react@^15.6.0', 'react-dom@^15.6.0', 'prop-types'];
+  const dependencies = ['react@^16.4.0', 'react-dom@^16.4.0', 'prop-types'];
+  const devDependencies = ['react-test-renderer@^16.4.0'];
   installDeps(dependencies, useYarn, verbose);
+  installDeps(devDependencies, useYarn, verbose, true);
 
   if (tryGitInit(appPath)) {
     console.log();
@@ -125,16 +127,17 @@ module.exports = (appPath, appName, verbose, originalDirectory) => {
   }
 };
 
-function installDeps(depedencies, useYarn, verbose) {
+function installDeps(depedencies, useYarn, verbose, isDev) {
   let command;
   let args;
 
   if (useYarn) {
     command = 'yarn';
     args = ['add'];
+    if (isDev) args.push('--dev');
   } else {
     command = 'npm';
-    args = ['install', '--save'];
+    args = ['install', isDev ? '--save-dev' : '--save'];
   }
 
   if (verbose) {

--- a/packages/mira-simulator/package.json
+++ b/packages/mira-simulator/package.json
@@ -19,8 +19,8 @@
     "mira-resources": "^2.1.0",
     "prop-types": "^15.6.1",
     "querystring": "^0.2.0",
-    "react": "^15.6.0",
-    "react-dom": "^15.6.0"
+    "react": "^16.4.0",
+    "react-dom": "^16.4.0"
   },
   "devDependencies": {
     "@babel/cli": "7.0.0-beta.42",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3553,17 +3553,19 @@ entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
 
-enzyme-adapter-react-15@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/enzyme-adapter-react-15/-/enzyme-adapter-react-15-1.0.5.tgz#99f9a03ff2c2303e517342935798a6bdfbb75fac"
+enzyme-adapter-react-16@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.1.1.tgz#a8f4278b47e082fbca14f5bfb1ee50ee650717b4"
   dependencies:
-    enzyme-adapter-utils "^1.1.0"
+    enzyme-adapter-utils "^1.3.0"
     lodash "^4.17.4"
     object.assign "^4.0.4"
     object.values "^1.0.4"
-    prop-types "^15.5.10"
+    prop-types "^15.6.0"
+    react-reconciler "^0.7.0"
+    react-test-renderer "^16.0.0-0"
 
-enzyme-adapter-utils@^1.1.0:
+enzyme-adapter-utils@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/enzyme-adapter-utils/-/enzyme-adapter-utils-1.3.0.tgz#d6c85756826c257a8544d362cc7a67e97ea698c7"
   dependencies:
@@ -3571,7 +3573,7 @@ enzyme-adapter-utils@^1.1.0:
     object.assign "^4.0.4"
     prop-types "^15.6.0"
 
-enzyme@^3.2.0:
+enzyme@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/enzyme/-/enzyme-3.3.0.tgz#0971abd167f2d4bf3f5bd508229e1c4b6dc50479"
   dependencies:
@@ -9471,7 +9473,7 @@ react-dev-utils@^5.0.0:
     strip-ansi "3.0.1"
     text-table "0.2.0"
 
-react-dom@^15.6.0, react-dom@^15.6.1:
+react-dom@^15.6.1:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.6.2.tgz#41cfadf693b757faf2708443a1d1fd5a02bef730"
   dependencies:
@@ -9479,6 +9481,15 @@ react-dom@^15.6.0, react-dom@^15.6.1:
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
     prop-types "^15.5.10"
+
+react-dom@^16.4.0:
+  version "16.4.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.4.0.tgz#099f067dd5827ce36a29eaf9a6cdc7cbf6216b1e"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
 
 react-error-overlay@^4.0.0:
   version "4.0.0"
@@ -9496,6 +9507,10 @@ react-event-listener@^0.5.1:
 react-flow-types@^0.2.0-beta.3:
   version "0.2.0-beta.6"
   resolved "https://registry.yarnpkg.com/react-flow-types/-/react-flow-types-0.2.0-beta.6.tgz#bf49c8b7864fcd0951b03286c63a80d66ce9fae4"
+
+react-is@^16.4.0:
+  version "16.4.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.4.0.tgz#cc9fdc855ac34d2e7d9d2eb7059bbc240d35ffcf"
 
 react-jss@^7.2.0:
   version "7.2.0"
@@ -9526,6 +9541,15 @@ react-popper@^0.7.4:
     popper.js "^1.12.5"
     prop-types "^15.5.10"
 
+react-reconciler@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.7.0.tgz#9614894103e5f138deeeb5eabaf3ee80eb1d026d"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
+
 react-redux@^5.0.6:
   version "5.0.7"
   resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-5.0.7.tgz#0dc1076d9afb4670f993ffaef44b8f8c1155a4c8"
@@ -9552,12 +9576,14 @@ react-style-proptype@^3.0.0:
   dependencies:
     prop-types "^15.5.4"
 
-react-test-renderer@^15.6.1:
-  version "15.6.2"
-  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-15.6.2.tgz#d0333434fc2c438092696ca770da5ed48037efa8"
+react-test-renderer@^16.0.0-0, react-test-renderer@^16.4.0:
+  version "16.4.0"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.4.0.tgz#0dbe0e24263e94e1830c7afb1f403707fad313a3"
   dependencies:
-    fbjs "^0.8.9"
-    object-assign "^4.1.0"
+    fbjs "^0.8.16"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
+    react-is "^16.4.0"
 
 react-transition-group@^2.2.1:
   version "2.3.1"
@@ -9567,7 +9593,7 @@ react-transition-group@^2.2.1:
     loose-envify "^1.3.1"
     prop-types "^15.6.1"
 
-react@^15.6.0, react@^15.6.1:
+react@^15.6.1:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/react/-/react-15.6.2.tgz#dba0434ab439cfe82f108f0f511663908179aa72"
   dependencies:
@@ -9576,6 +9602,15 @@ react@^15.6.0, react@^15.6.1:
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
     prop-types "^15.5.10"
+
+react@^16.4.0:
+  version "16.4.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.4.0.tgz#402c2db83335336fba1962c08b98c6272617d585"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
 
 read-all-stream@^3.0.0:
   version "3.1.0"


### PR DESCRIPTION
Also now installs react-test-renderer as a dev dependency when running `create-mira-app`.