### PR TITLE
Update onCompleteTimeout avoid indefinite duration if setting state

### DIFF
--- a/examples/menu/src/index.js
+++ b/examples/menu/src/index.js
@@ -35,8 +35,7 @@ class Menu extends Component {
 
   componentDidUpdate() {
     const { isPlaying, presentation, onComplete } = this.props;
-    if (isPlaying) {
-      clearTimeout(this.onCompleteTimeout);
+    if (isPlaying && !this.onCompleteTimeout) {
       this.onCompleteTimeout = setTimeout(
         onComplete,
         presentation.values.duration * 1000,

--- a/examples/weather/src/index.js
+++ b/examples/weather/src/index.js
@@ -41,9 +41,7 @@ class Weather extends Component {
       await this.fetchWeatherData();
     }
     // Start onComplete timeout when app becomes visible.
-    if (isPlaying) {
-      // Clear existing timeout when props are updated.
-      clearTimeout(this.onCompleteTimeout);
+    if (isPlaying && !this.onCompleteTimeout) {
       this.onCompleteTimeout = setTimeout(onComplete, duration * 1000);
     }
   }

--- a/packages/mira-scripts/template/src/index.js
+++ b/packages/mira-scripts/template/src/index.js
@@ -23,9 +23,7 @@ class App extends Component {
   componentDidUpdate(prevProps) {
     const { isPlaying, duration, onComplete } = this.props;
     // The app is visible start the onComplete timeout.
-    if (isPlaying) {
-      // Clear existing timeout when props are updated.
-      clearTimeout(this.onCompleteTimeout);
+    if (isPlaying && !this.onCompleteTimeout) {
       this.onCompleteTimeout = setTimeout(onComplete, duration * 1000);
     }
   }


### PR DESCRIPTION
As we discovered in the News app, clearing the timeout in `componentDidUpdate` causes an indefinite duration when setting state.

Updated the template and examples to reflect this best practice.