### PR TITLE
OAuth prop type

### DIFF
--- a/packages/mira-kit/src/prop-types/OAuthType.ts
+++ b/packages/mira-kit/src/prop-types/OAuthType.ts
@@ -1,0 +1,24 @@
+import BaseType, { PropType } from './BaseType';
+
+interface OAuthPropType extends PropType {
+  authUrl: string;
+  verifyUrl: string;
+  verifyQsParam: string;
+}
+
+export default class OAuthType extends BaseType<OAuthPropType> {
+  constructor(label: string) {
+    super(label, 'oAuth');
+  }
+
+  authUrl(url: string) {
+    this.propType.authUrl = url;
+    return this;
+  }
+
+  verifyUrl(url: string, queryStringParam: string = 'token') {
+    this.propType.verifyUrl = url;
+    this.propType.verifyQsParam = queryStringParam;
+    return this;
+  }
+}

--- a/packages/mira-kit/src/prop-types/extractProperties.test.ts
+++ b/packages/mira-kit/src/prop-types/extractProperties.test.ts
@@ -5,6 +5,7 @@ import {
   file,
   image,
   number,
+  oAuth,
   selection,
   string,
   text,
@@ -471,4 +472,48 @@ test('Should set maxItems constraint', () => {
 
   const { properties } = extractProperties(propTypes);
   expect(properties[0].constraints).toEqual({ max_items: 4 });
+});
+
+test('Should extract properties for oAuth', () => {
+  const propTypes = {
+    oAuth: oAuth('Connect')
+      .authUrl('https://example.com/auth')
+      .verifyUrl('https://example.com/verify', 'accessToken')
+      .helperText('helperText')
+      .helperLink('https://example.com/help')
+      .required(),
+  };
+
+  const { properties, strings } = extractProperties(propTypes);
+  expect(strings).toEqual({
+    oAuth: 'Connect',
+    oAuth_helperText: 'helperText',
+  });
+  expect(properties).toEqual([
+    {
+      type: 'oAuth',
+      name: 'oAuth',
+      optional: false,
+      auth_url: 'https://example.com/auth',
+      verify_url: 'https://example.com/verify',
+      verify_qs_param: 'accessToken',
+      helper_text: 'oAuth_helperText',
+      helper_link: 'https://example.com/help',
+      constraints: {},
+    },
+  ]);
+});
+
+test('Should throw for oAuth property without auth url', () => {
+  const propTypes = {
+    oAuth: oAuth('Connect').verifyUrl('https://example.com/verify'),
+  };
+  expect(() => extractProperties(propTypes)).toThrow();
+});
+
+test('Should throw for oAuth property without verify url', () => {
+  const propTypes = {
+    oAuth: oAuth('Connect').authUrl('https://example.com/auth'),
+  };
+  expect(() => extractProperties(propTypes)).toThrow();
 });

--- a/packages/mira-kit/src/prop-types/extractProperties.ts
+++ b/packages/mira-kit/src/prop-types/extractProperties.ts
@@ -63,6 +63,25 @@ export default function extractProperties(
       }
     }
 
+    if (propType.type === 'oAuth') {
+      const { authUrl, verifyUrl, verifyQsParam } = propType;
+
+      if (!authUrl) {
+        throw new Error(
+          'Error extracting properties: OAuth type must set authUrl.',
+        );
+      }
+      if (!verifyUrl) {
+        throw new Error(
+          'Error extracting properties: OAuth type must set verifyUrl.',
+        );
+      }
+
+      prop.auth_url = authUrl;
+      prop.verify_url = verifyUrl;
+      prop.verify_qs_param = verifyQsParam;
+    }
+
     properties.push(prop);
   });
 

--- a/packages/mira-kit/src/prop-types/index.ts
+++ b/packages/mira-kit/src/prop-types/index.ts
@@ -3,6 +3,7 @@ import BooleanType from './BooleanType';
 import FileType from './FileType';
 import ImageType from './ImageType';
 import NumberType from './NumberType';
+import OAuthType from './OAuthType';
 import SelectionType from './SelectionType';
 import StringType from './StringType';
 import TextType from './TextType';
@@ -17,6 +18,7 @@ export const file = (label: string) => new FileType(label);
 export const image = (label: string) => new ImageType(label);
 // tslint:disable-next-line
 export const number = (label: string) => new NumberType(label);
+export const oAuth = (label: string) => new OAuthType(label);
 export const selection = (label: string) => new SelectionType(label);
 // tslint:disable-next-line
 export const string = (label: string) => new StringType(label);

--- a/packages/mira-simulator/index.html
+++ b/packages/mira-simulator/index.html
@@ -17,6 +17,8 @@
       height: 100%;
     }
   </style>
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/6.26.0/polyfill.min.js"></script>
 </head>
 
 <body>

--- a/packages/mira-simulator/package.json
+++ b/packages/mira-simulator/package.json
@@ -14,7 +14,7 @@
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
     "eventemitter3": "^3.0.1",
     "fast-deep-equal": "^1.1.0",
-    "mira-elements": "^0.30.2",
+    "mira-elements": "^0.31.0",
     "mira-kit": "^3.6.0",
     "mira-resources": "^3.6.0",
     "prop-types": "^15.6.1",

--- a/packages/mira-simulator/webpack.config.js
+++ b/packages/mira-simulator/webpack.config.js
@@ -73,7 +73,7 @@ module.exports = {
       inject: true,
       template: 'index.html',
     }),
-    // Temporarily disable React production build to supress warnings in development.
+    // Temporarily disable React production build to suppress warnings in development.
     // This will end up building with the development when running the static build.
     // We should probably create two builds of the simulator for development and production.
     // new webpack.DefinePlugin({

--- a/yarn.lock
+++ b/yarn.lock
@@ -7699,9 +7699,9 @@ minimist@~0.0.1:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
-mira-elements@^0.30.2:
-  version "0.30.2"
-  resolved "https://registry.yarnpkg.com/mira-elements/-/mira-elements-0.30.2.tgz#055e32cf18c6c5d8f6f06846fd08c9541a1e9ce1"
+mira-elements@^0.31.0:
+  version "0.31.0"
+  resolved "https://registry.yarnpkg.com/mira-elements/-/mira-elements-0.31.0.tgz#672e42693833532532a0913838d1d40fc5c2537a"
   dependencies:
     array-equal "^1.0.0"
     babel-runtime "^6.25.0"


### PR DESCRIPTION
Adds an OAuth prop type.

Usage:
```js
// mira.config.js
import { oAuth } from 'mira-kit/prop-types'

export default {
  properties: {
    accessToken: oAuth('Connect to Instagram')
      .authUrl('https://my-endpoint.com/auth')
      .verifyUrl('https://my-endpoint.com/verify')
  }
}
```

Leaving undocumented for now while we test the feature in production. We'll want to add an example in the future.