### PR TITLE
Add support for multi selects and remote options

### DIFF
--- a/packages/mira-kit/src/prop-types/SelectionType.ts
+++ b/packages/mira-kit/src/prop-types/SelectionType.ts
@@ -7,15 +7,14 @@ interface Option {
 
 export interface SelectionPropType extends PropType {
   default: string;
-  exclusive: boolean;
+  multiple: boolean;
   options: Option[];
+  optionsUrl: string;
 }
 
 export default class SelectionType extends BaseType<SelectionPropType> {
   constructor(label: string) {
     super(label, 'selection');
-    // We currently don't support multi-selects.
-    this.propType.exclusive = true;
     this.propType.options = [];
   }
 
@@ -24,9 +23,19 @@ export default class SelectionType extends BaseType<SelectionPropType> {
     return this;
   }
 
+  multiple(value = true) {
+    this.propType.multiple = value;
+    return this;
+  }
+
   option(value: string, label: string) {
     if (!label) label = value;
     this.propType.options.push({ label, value });
+    return this;
+  }
+
+  optionsUrl(url: string) {
+    this.propType.optionsUrl = url;
     return this;
   }
 }

--- a/packages/mira-kit/src/prop-types/extractProperties.test.ts
+++ b/packages/mira-kit/src/prop-types/extractProperties.test.ts
@@ -307,6 +307,8 @@ test('Should extract properties from selection', () => {
     helper: selection('Selection')
       .helperText('helperText')
       .helperLink('http://helper.link'),
+    multiple: selection('Selection').multiple(),
+    optionsUrl: selection('Selection').optionsUrl('https://options.url'),
   };
 
   const { properties, strings } = extractProperties(propTypes);
@@ -318,12 +320,13 @@ test('Should extract properties from selection', () => {
     b: 'B',
     helper: 'Selection',
     helper_helperText: 'helperText',
+    multiple: 'Selection',
+    optionsUrl: 'Selection',
   });
   expect(properties).toEqual([
     {
       type: 'selection',
       name: 'optional',
-      exclusive: true,
       optional: true,
       options: [],
       constraints: {},
@@ -331,7 +334,6 @@ test('Should extract properties from selection', () => {
     {
       type: 'selection',
       name: 'required',
-      exclusive: true,
       optional: false,
       options: [],
       constraints: {},
@@ -339,7 +341,6 @@ test('Should extract properties from selection', () => {
     {
       type: 'selection',
       name: 'options',
-      exclusive: true,
       optional: true,
       options: [{ name: 'a', value: 'a' }, { name: 'b', value: 'b' }],
       default: 'a',
@@ -348,14 +349,39 @@ test('Should extract properties from selection', () => {
     {
       type: 'selection',
       name: 'helper',
-      exclusive: true,
       optional: true,
       helper_text: 'helper_helperText',
       helper_link: 'http://helper.link',
       constraints: {},
       options: [],
     },
+    {
+      type: 'selection',
+      name: 'multiple',
+      multiple: true,
+      optional: true,
+      constraints: {},
+      options: [],
+    },
+    {
+      type: 'selection',
+      name: 'optionsUrl',
+      optional: true,
+      constraints: {},
+      options: [],
+      options_url: 'https://options.url',
+    },
   ]);
+});
+
+test('Should not allow selection types to specify options and optionUrl', () => {
+  const propTypes = {
+    selection: selection('Selection')
+      .optionsUrl('http://options.url')
+      .option('value', 'label'),
+  };
+
+  expect(() => extractProperties(propTypes)).toThrow();
 });
 
 test('Should extract properties from string', () => {

--- a/packages/mira-kit/src/prop-types/extractProperties.ts
+++ b/packages/mira-kit/src/prop-types/extractProperties.ts
@@ -35,7 +35,18 @@ export default function extractProperties(
 
     if (propType.type === 'selection') {
       prop.options = [];
-      prop.exclusive = propType.exclusive;
+      prop.multiple = propType.multiple;
+
+      if (propType.optionsUrl && propType.options.length > 0) {
+        throw new Error(
+          `Cannot set both an optionsUrl and options for selection '${
+            propType.label
+          }'`,
+        );
+      }
+
+      prop.options_url = propType.optionsUrl;
+
       (propType as SelectionPropType).options.forEach(option => {
         strings[option.value] = option.label;
         prop.options.push({ name: option.value, value: option.value });

--- a/packages/mira-simulator/package.json
+++ b/packages/mira-simulator/package.json
@@ -14,7 +14,7 @@
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
     "eventemitter3": "^3.0.1",
     "fast-deep-equal": "^1.1.0",
-    "mira-elements": "^0.32.0",
+    "mira-elements": "^0.33.0",
     "mira-kit": "^3.8.0",
     "mira-resources": "^3.8.0",
     "prop-types": "^15.6.1",

--- a/packages/mira-simulator/src/Simulator.js
+++ b/packages/mira-simulator/src/Simulator.js
@@ -196,8 +196,6 @@ class MiraAppSimulator extends Component {
   queuePresentationUpdate = (presentation, changedProp) => {
     let presentationPreview;
 
-    console.log('queuePresentationUpdate', presentation);
-
     // Delay updating the preview for text and string inputs until onBlur.
     if (changedProp.type === 'string' || changedProp.type === 'text') {
       this.queuedPresentationPreview = presentation;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7699,9 +7699,9 @@ minimist@~0.0.1:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
-mira-elements@^0.32.0:
-  version "0.32.0"
-  resolved "https://registry.yarnpkg.com/mira-elements/-/mira-elements-0.32.0.tgz#5adcee69eb251d26b4ccbefdbfa42a4ace765367"
+mira-elements@^0.33.0:
+  version "0.33.0"
+  resolved "https://registry.yarnpkg.com/mira-elements/-/mira-elements-0.33.0.tgz#5f372fed8445d982b584240e2b3879786ea7295f"
   dependencies:
     array-equal "^1.0.0"
     babel-runtime "^6.25.0"


### PR DESCRIPTION
https://trello.com/c/bjjO6zbK/133-add-multi-select-and-dynamic-options-to-mirakit

```js
//mira.config.js
export default {
   ...
   properties: {
    ...
    calendars: PropTypes.selection('Calendars')
      .multiple()
      .optionsUrl('https://.../calendars?access_token={{accessToken}}'),
  }
}