### PR TITLE
Fix isThumbnail prop not explicitly passed down

### DIFF
--- a/packages/mira-kit/src/withMiraApp.test.tsx
+++ b/packages/mira-kit/src/withMiraApp.test.tsx
@@ -36,11 +36,13 @@ const App: React.SFC<any> = () => <div />;
 test('Should render app', () => {
   const props = createProps();
   const MiraApp = withMiraApp(App);
-  const wrapper = shallow(<MiraApp {...props} isDashboard={true} />);
+  const wrapper = shallow(
+    <MiraApp {...props} isDashboard={true} isThumbnail={true} />,
+  );
   const app = wrapper.find(App);
   expect(app.length).toEqual(1);
   const appProps = app.props();
-  expect(Object.keys(appProps).length).toEqual(10);
+  expect(Object.keys(appProps).length).toEqual(11);
   expect(appProps.presentation.name).toEqual(props.presentation.name);
   expect(appProps.presentation.values).toEqual(
     props.presentation.application_vars,
@@ -67,6 +69,7 @@ test('Should render app', () => {
   expect(appProps.miraFileResource).toEqual(props.miraFileResource);
   expect(appProps.strings).toEqual(props.strings);
   expect(appProps.isDashboard).toEqual(true);
+  expect(appProps.isThumbnail).toEqual(true);
 });
 
 test('Should render error', () => {

--- a/packages/mira-kit/src/withMiraApp.tsx
+++ b/packages/mira-kit/src/withMiraApp.tsx
@@ -19,6 +19,7 @@ interface MiraAppProps {
   miraEvents: EventEmitter;
   strings: { [key: string]: string };
   isDashboard: boolean;
+  isThumbnail: boolean;
   // Deprecated.
   miraFileResource: (file: { url: string }) => any;
   miraRequestResource: (url: string) => any;
@@ -169,6 +170,7 @@ export default function withMiraApp(
         miraRequestResource,
         strings,
         isDashboard,
+        isThumbnail,
         ...legacyApplicationVars
       } = this.props;
 
@@ -185,6 +187,7 @@ export default function withMiraApp(
           miraRequestResource={miraRequestResource}
           strings={strings}
           isDashboard={isDashboard}
+          isThumbnail={isThumbnail}
         />
       );
     }

--- a/packages/mira-simulator/src/AppPreview.js
+++ b/packages/mira-simulator/src/AppPreview.js
@@ -84,6 +84,7 @@ class AppPreview extends Component {
         allowedRequestDomains,
       ),
       isDashboard: simulatorOptions.isDashboard,
+      isThumbnail: simulatorOptions.isThumbnail,
     };
 
     return children(props);


### PR DESCRIPTION
`isThumbnail` is passed in from the screenshot service. This wasn't actually broken because it was being accidentally passed down via `legacyApplicationVars`. 

We also didn't have a way for the simulator to set this value but now you can with:

```js
// mira.config.js

export default {
   simulator: {
     isThumbnail: true
  }
}
```