### PR TITLE
Added SoundZone prop type and simulator option

### DIFF
--- a/packages/mira-kit/src/prop-types/SoundZoneType.ts
+++ b/packages/mira-kit/src/prop-types/SoundZoneType.ts
@@ -1,0 +1,7 @@
+import BaseType, { PropType } from './BaseType';
+
+export default class SoundZoneType extends BaseType<PropType> {
+  constructor(label = 'Sound Zone') {
+    super(label, 'soundZone');
+  }
+}

--- a/packages/mira-kit/src/prop-types/extractProperties.test.ts
+++ b/packages/mira-kit/src/prop-types/extractProperties.test.ts
@@ -8,6 +8,7 @@ import {
   number,
   oAuth,
   selection,
+  soundZone,
   string,
   text,
   theme,
@@ -558,7 +559,7 @@ test('Should extract properties for facebookAuth', () => {
       .required(),
   };
 
-  const { properties, strings } = extractProperties(propTypes);
+  const { properties } = extractProperties(propTypes);
   expect(properties).toEqual([
     {
       type: 'facebookAuth',
@@ -583,7 +584,7 @@ test('Should extract properties for googleAuth', () => {
       .required(),
   };
 
-  const { properties, strings } = extractProperties(propTypes);
+  const { properties } = extractProperties(propTypes);
   expect(properties).toEqual([
     {
       type: 'googleAuth',
@@ -594,6 +595,30 @@ test('Should extract properties for googleAuth', () => {
       verify_qs_param: 'accessToken',
       logout_url: 'https://example.com/logout',
       logout_qs_param: 'accessToken',
+      constraints: {},
+    },
+  ]);
+});
+
+test('Should extract properties for soundZone', () => {
+  const propTypes = {
+    soundZone: soundZone('SoundZone')
+      .helperText('helperText')
+      .helperLink('https://example.com/help'),
+  };
+
+  const { properties, strings } = extractProperties(propTypes);
+  expect(strings).toEqual({
+    soundZone: 'SoundZone',
+    soundZone_helperText: 'helperText',
+  });
+  expect(properties).toEqual([
+    {
+      type: 'soundZone',
+      name: 'soundZone',
+      optional: true,
+      helper_text: 'soundZone_helperText',
+      helper_link: 'https://example.com/help',
       constraints: {},
     },
   ]);

--- a/packages/mira-kit/src/prop-types/index.ts
+++ b/packages/mira-kit/src/prop-types/index.ts
@@ -7,6 +7,7 @@ import ImageType from './ImageType';
 import NumberType from './NumberType';
 import OAuthType from './OAuthType';
 import SelectionType from './SelectionType';
+import SoundZoneType from './SoundZoneType';
 import StringType from './StringType';
 import TextType from './TextType';
 import ThemeType from './ThemeType';
@@ -23,6 +24,7 @@ export const image = (label: string) => new ImageType(label);
 // tslint:disable-next-line
 export const number = (label: string) => new NumberType(label);
 export const oAuth = (label: string) => new OAuthType(label);
+export const soundZone = (label: string) => new SoundZoneType(label);
 export const selection = (label: string) => new SelectionType(label);
 // tslint:disable-next-line
 export const string = (label: string) => new StringType(label);

--- a/packages/mira-simulator/package.json
+++ b/packages/mira-simulator/package.json
@@ -14,7 +14,7 @@
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
     "eventemitter3": "^3.0.1",
     "fast-deep-equal": "^1.1.0",
-    "mira-elements": "^0.33.2",
+    "mira-elements": "^0.34.0",
     "mira-kit": "^3.10.0",
     "mira-resources": "^3.9.2",
     "prop-types": "^15.6.1",

--- a/packages/mira-simulator/src/Simulator.js
+++ b/packages/mira-simulator/src/Simulator.js
@@ -303,6 +303,7 @@ class MiraAppSimulator extends Component {
     presentationPreview = mergeDefaultAppVars(
       { ...presentationPreview, name: presentationPreview.name || ' ' },
       appVersion,
+      simulatorOptions.soundZones,
     );
 
     const previewErrors = PresentationBuilderForm.validate(
@@ -356,7 +357,11 @@ class MiraAppSimulator extends Component {
     }
 
     const presentationWithDefaults = {
-      ...mergeDefaultAppVars(presentation, appVersion),
+      ...mergeDefaultAppVars(
+        presentation,
+        appVersion,
+        simulatorOptions.soundZones,
+      ),
       id: String(presentation.id),
     };
 
@@ -370,6 +375,7 @@ class MiraAppSimulator extends Component {
                 presentation={presentationWithDefaults}
                 appVersion={appVersion}
                 themes={simulatorOptions.themes}
+                soundZones={simulatorOptions.soundZones}
                 onChange={this.queuePresentationUpdate}
                 onBlur={this.flushPreviewUpdate}
               />

--- a/packages/mira-simulator/src/mergeDefaultAppVars.js
+++ b/packages/mira-simulator/src/mergeDefaultAppVars.js
@@ -1,12 +1,15 @@
-export default (presentation, appVersion) => {
-  const appVars = presentation.application_vars;
+export default (presentation, appVersion, soundZones = []) => {
+  const appVars = { ...presentation.application_vars };
 
   appVersion.presentation_properties.forEach(prop => {
-    if (
-      typeof prop.default !== 'undefined' &&
-      typeof appVars[prop.name] === 'undefined'
-    ) {
-      appVars[prop.name] = prop.default;
+    const propValue = appVars[prop.name];
+
+    if (propValue === undefined) {
+      if (prop.type === 'soundZone' && soundZones.length > 0) {
+        appVars[prop.name] = soundZones[0].id;
+      } else if (prop.default !== undefined) {
+        appVars[prop.name] = prop.default;
+      }
     }
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7699,9 +7699,10 @@ minimist@~0.0.1:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
-mira-elements@^0.33.2:
-  version "0.33.2"
-  resolved "https://registry.yarnpkg.com/mira-elements/-/mira-elements-0.33.2.tgz#a838743b9ca805355d11fe464ad43d930d787c18"
+mira-elements@^0.34.0:
+  version "0.34.0"
+  resolved "https://registry.yarnpkg.com/mira-elements/-/mira-elements-0.34.0.tgz#48b17b55556da88fa349544e2b301b1969979d88"
+  integrity sha512-5ajhTIHhlmWeIwUHl/8btWaF4+3WH0aCcW+Etqn0n0dTW952IHxmE4EWNnSWdcXIaLK7GDNJ26st9ICmTL3cyw==
   dependencies:
     array-equal "^1.0.0"
     babel-runtime "^6.25.0"


### PR DESCRIPTION
Adds support for the sound zone prop type:

```js
// mira.config.js
export {
  properties: {
     soundZone: PropTypes.soundZones()
  },

  simulator: [
   soundZones: [{ id: '..', name: '...' }]
  ]
}
```
----
https://trello.com/c/Pr55uEZ3/258-5-create-a-sound-zone-dropdown-for-the-now-playing-app-dash-v2

- [x] Depends on https://github.com/mirainc/mira-elements/pull/174
----
