### PR TITLE
add device enable-dev-url command to webpack build

### DIFF
--- a/packages/mira-scripts/scripts/start.js
+++ b/packages/mira-scripts/scripts/start.js
@@ -34,6 +34,13 @@ async function start() {
   const appName = require(paths.appPackageJson).name;
   const port = await choosePort(host, defaultPort);
   const urls = prepareUrls(protocol, host, port);
+  // Inject custom urls for Mira device
+  urls.lanUrlForTerminal = `${urls.lanUrlForTerminal}\n
+  Run the following to view your app on your dev device:\n
+  mira-cli device action enable-dev-url <device_id> '${protocol}://${
+    urls.lanUrlForConfig
+  }:${port}/?fullScreen=true&present=true'
+  `;
   const compiler = createCompiler(
     webpack,
     createConfig(configPath),


### PR DESCRIPTION
```
Compiled successfully!

You can now view my-app in the browser.

  Local:            http://localhost:3000/
  On Your Network:  http://172.16.4.224:3000/

  Run the following to view your app on your dev device:

  mira-cli device action enable-dev-url <device_id> 'http://172.16.4.224:3000/?fullScreen=true&present=true'
  

Note that the development build is not optimized.
To create a production build, use yarn build.
```